### PR TITLE
OP-981: Pricelist services/items name validation

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -239,13 +239,13 @@ export function medicalServicesValidationCheck(mm, variables) {
     }
     `,
     variables,
-    `PRICELIST_SERVICES_VALIDATION_FIELDS`,
+    `PRICELIST_SERVICES_FIELDS_VALIDATION`,
   );
 }
 
 export function medicalServicesValidationClear() {
   return (dispatch) => {
-    dispatch({ type: `PRICELIST_SERVICES_VALIDATION_FIELDS_CLEAR` });
+    dispatch({ type: `PRICELIST_SERVICES_FIELDS_VALIDATION_CLEAR` });
   };
 }
 
@@ -257,13 +257,13 @@ export function medicalItemsValidationCheck(mm, variables) {
     }
     `,
     variables,
-    `PRICELIST_ITEMS_VALIDATION_FIELDS`,
+    `PRICELIST_ITEMS_FIELDS_VALIDATION`,
   );
 }
 
 export function medicalItemsValidationClear() {
   return (dispatch) => {
-    dispatch({ type: `PRICELIST_ITEMS_VALIDATION_FIELDS_CLEAR` });
+    dispatch({ type: `PRICELIST_ITEMS_FIELDS_VALIDATION_CLEAR` });
   };
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,6 +6,7 @@ import {
   formatPageQuery,
   decodeId,
   graphqlMutation,
+  graphqlWithVariables,
 } from "@openimis/fe-core";
 import { ITEMS_PRICELIST_TYPE, SERVICES_PRICELIST_TYPE } from "./constants";
 
@@ -228,4 +229,46 @@ export function deleteItemsPricelist(mm, uuid, clientMutationLabel) {
   `,
     { input: { uuids: [uuid], clientMutationLabel } }
   );
+}
+
+export function medicalServicesValidationCheck(mm, variables) {
+  return graphqlWithVariables(
+    `
+    query ($servicesPricelistName: String!) {
+      isValid: validateServicesPricelistName(servicesPricelistName: $servicesPricelistName)
+    }
+    `,
+    variables,
+    `PRICELIST_SERVICES_VALIDATION_FIELDS`,
+  );
+}
+
+export function medicalServicesValidationClear() {
+  return (dispatch) => {
+    dispatch({ type: `PRICELIST_SERVICES_VALIDATION_FIELDS_CLEAR` });
+  };
+}
+
+export function medicalItemsValidationCheck(mm, variables) {
+  return graphqlWithVariables(
+    `
+    query ($itemsPricelistName: String!) {
+      isValid: validateItemsPricelistName(itemsPricelistName: $itemsPricelistName)
+    }
+    `,
+    variables,
+    `PRICELIST_ITEMS_VALIDATION_FIELDS`,
+  );
+}
+
+export function medicalItemsValidationClear() {
+  return (dispatch) => {
+    dispatch({ type: `PRICELIST_ITEMS_VALIDATION_FIELDS_CLEAR` });
+  };
+}
+
+export function clearMedicalPricelistItems() {
+  return (dispatch) => {
+    dispatch({ type: "MEDICAL_PRICELIST_PRICELIST_CLEAR" });
+  };
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -267,7 +267,7 @@ export function medicalItemsValidationClear() {
   };
 }
 
-export function clearMedicalPricelistItems() {
+export function clearMedicalPricelists() {
   return (dispatch) => {
     dispatch({ type: "MEDICAL_PRICELIST_PRICELIST_CLEAR" });
   };

--- a/src/components/PricelistForm.js
+++ b/src/components/PricelistForm.js
@@ -10,13 +10,24 @@ import PricelistGeneralPanel from "./PricelistGeneralPanel";
 import PricelistDetailsPanel from "./PricelistDetailsPanel";
 
 const PricelistForm = (props) => {
-  const { readOnly, onBack, onSave, onReset, pricelist, onChange, fetchDetails, details, isValid, clearMedicalPricelists} = props;
+  const {
+    readOnly,
+    onBack,
+    onSave,
+    onReset,
+    pricelist,
+    onChange,
+    fetchDetails,
+    details,
+    isValid,
+    clearMedicalPricelists,
+  } = props;
   const canSave = () => pricelist.name && pricelist.pricelistDate && isValid === true;
 
   useEffect(() => {
-    return () => { 
+    return () => {
       clearMedicalPricelists();
-    }
+    };
   }, []);
 
   return (
@@ -49,7 +60,9 @@ const PricelistForm = (props) => {
 };
 
 const mapStateToProps = (state) => ({
-  isValid: !!state.medical_pricelist.validationFields?.medicalServices?.isValid || !!state.medical_pricelist.validationFields?.medicalItems?.isValid,
+  isValid:
+    !!state.medical_pricelist.validationFields?.medicalServices?.isValid ||
+    !!state.medical_pricelist.validationFields?.medicalItems?.isValid,
 });
 
 const mapDispatchToProps = (dispatch) => {

--- a/src/components/PricelistForm.js
+++ b/src/components/PricelistForm.js
@@ -1,11 +1,13 @@
 import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+
+import ReplayIcon from "@material-ui/icons/Replay";
+
 import { withHistory, withModulesManager, Form } from "@openimis/fe-core";
+import { clearMedicalPricelistItems } from "../actions";
 import PricelistGeneralPanel from "./PricelistGeneralPanel";
 import PricelistDetailsPanel from "./PricelistDetailsPanel";
-import ReplayIcon from "@material-ui/icons/Replay";
-import { clearMedicalPricelistItems } from "../actions";
 
 const PricelistForm = (props) => {
   const { readOnly, onBack, onSave, onReset, pricelist, onChange, fetchDetails, details, isValid, clearMedicalPricelistItems} = props;

--- a/src/components/PricelistForm.js
+++ b/src/components/PricelistForm.js
@@ -5,17 +5,17 @@ import { bindActionCreators } from "redux";
 import ReplayIcon from "@material-ui/icons/Replay";
 
 import { withHistory, withModulesManager, Form } from "@openimis/fe-core";
-import { clearMedicalPricelistItems } from "../actions";
+import { clearMedicalPricelists } from "../actions";
 import PricelistGeneralPanel from "./PricelistGeneralPanel";
 import PricelistDetailsPanel from "./PricelistDetailsPanel";
 
 const PricelistForm = (props) => {
-  const { readOnly, onBack, onSave, onReset, pricelist, onChange, fetchDetails, details, isValid, clearMedicalPricelistItems} = props;
+  const { readOnly, onBack, onSave, onReset, pricelist, onChange, fetchDetails, details, isValid, clearMedicalPricelists} = props;
   const canSave = () => pricelist.name && pricelist.pricelistDate && isValid === true;
 
   useEffect(() => {
     return () => { 
-      clearMedicalPricelistItems();
+      clearMedicalPricelists();
     }
   }, []);
 
@@ -53,7 +53,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ clearMedicalPricelistItems }, dispatch);
+  return bindActionCreators({ clearMedicalPricelists }, dispatch);
 };
 
 export default withHistory(withModulesManager(connect(mapStateToProps, mapDispatchToProps)(PricelistForm)));

--- a/src/components/PricelistForm.js
+++ b/src/components/PricelistForm.js
@@ -1,12 +1,22 @@
-import React from "react";
-import { combine, withHistory, withModulesManager, Form } from "@openimis/fe-core";
+import React, { useEffect } from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { withHistory, withModulesManager, Form } from "@openimis/fe-core";
 import PricelistGeneralPanel from "./PricelistGeneralPanel";
 import PricelistDetailsPanel from "./PricelistDetailsPanel";
 import ReplayIcon from "@material-ui/icons/Replay";
+import { clearMedicalPricelistItems } from "../actions";
 
 const PricelistForm = (props) => {
-  const { readOnly, onBack, onSave, onReset, pricelist, onChange, fetchDetails, details } = props;
-  const canSave = () => pricelist.name && pricelist.pricelistDate;
+  const { readOnly, onBack, onSave, onReset, pricelist, onChange, fetchDetails, details, isValid, clearMedicalPricelistItems} = props;
+  const canSave = () => pricelist.name && pricelist.pricelistDate && isValid === true;
+
+  useEffect(() => {
+    return () => { 
+      clearMedicalPricelistItems();
+    }
+  }, []);
+
   return (
     <>
       <Form
@@ -36,5 +46,12 @@ const PricelistForm = (props) => {
   );
 };
 
-const enhance = combine(withHistory, withModulesManager);
-export default enhance(PricelistForm);
+const mapStateToProps = (state) => ({
+  isValid: !!state.medical_pricelist.validationFields?.medicalServices?.isValid || !!state.medical_pricelist.validationFields?.medicalItems?.isValid,
+});
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ clearMedicalPricelistItems }, dispatch);
+};
+
+export default withHistory(withModulesManager(connect(mapStateToProps, mapDispatchToProps)(PricelistForm)));

--- a/src/components/PricelistGeneralPanel.js
+++ b/src/components/PricelistGeneralPanel.js
@@ -4,7 +4,10 @@ import { connect } from "react-redux";
 import { withStyles, withTheme } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 
-import { FormPanel, withHistory, withModulesManager, PublishedComponent, ValidatedTextInput } from "@openimis/fe-core";
+import { 
+  FormPanel, withHistory, withModulesManager, 
+  PublishedComponent, ValidatedTextInput 
+} from "@openimis/fe-core";
 import {
   medicalServicesValidationCheck,
   medicalServicesValidationClear,

--- a/src/components/PricelistGeneralPanel.js
+++ b/src/components/PricelistGeneralPanel.js
@@ -1,8 +1,17 @@
 import React from "react";
-import { withStyles, withTheme } from "@material-ui/core/styles";
+import { connect } from "react-redux";
 
+import { withStyles, withTheme } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
-import { FormPanel, withHistory, combine, withModulesManager, TextInput, PublishedComponent } from "@openimis/fe-core";
+
+import { FormPanel, withHistory, withModulesManager, PublishedComponent, ValidatedTextInput } from "@openimis/fe-core";
+import {
+  medicalServicesValidationCheck,
+  medicalServicesValidationClear,
+  medicalItemsValidationCheck,
+  medicalItemsValidationClear,
+} from "../actions";
+import { SERVICES_PRICELIST_TYPE } from "../constants";
 
 const styles = (theme) => ({
   item: theme.paper.item,
@@ -12,23 +21,50 @@ class PricelistGeneralPanel extends FormPanel {
   onRegionChange = (value) => {
     this.updateAttribute("location", value);
   };
+
   onDistrictChange = (value) => {
     this.updateAttribute("location", value ?? this.props.edited.location?.parent);
   };
 
+  shouldValidate = (inputValue) => {
+    const { savedServiceName, savedItemName } = this.props;
+    const shouldValidate = inputValue !== (savedServiceName || savedItemName);
+    return shouldValidate;
+  };
+
   render() {
-    const { classes, readOnly, edited } = this.props;
+    const {
+      classes,
+      readOnly,
+      edited,
+      isMedicalServiceValid,
+      isMedicalServiceValidating,
+      medicalServiceValidationError,
+      isMedicalItemValid,
+      isMedicalItemValidating,
+      medicalItemValidationError,
+      activeType,
+    } = this.props;
     const region = edited.location?.parent ?? edited.location;
     const district = edited.location?.parent ? edited.location : null;
+    const servicesOrItems = activeType === SERVICES_PRICELIST_TYPE;
     return (
       <>
         <Grid container>
           <Grid item xs={4} className={classes.item}>
-            <TextInput
-              module={"medical_pricelist"}
-              label={"medical_pricelist.name"}
-              onChange={(v) => this.updateAttribute("name", v)}
-              required
+            <ValidatedTextInput
+              action={servicesOrItems ? medicalServicesValidationCheck : medicalItemsValidationCheck}
+              clearAction={servicesOrItems ? medicalServicesValidationClear : medicalItemsValidationClear}
+              itemQueryIdentifier={servicesOrItems ? "servicesPricelistName" : "itemsPricelistName"}
+              isValid={servicesOrItems ? isMedicalServiceValid : isMedicalItemValid}
+              isValidating={servicesOrItems ? isMedicalServiceValidating : isMedicalItemValidating}
+              validationError={servicesOrItems ? medicalServiceValidationError : medicalItemValidationError}
+              shouldValidate={this.shouldValidate}
+              module="medical_pricelist"
+              label="medical_pricelist.name"
+              codeTakenLabel="medical_pricelist.nameTaken"
+              onChange={(name) => this.updateAttribute("name", name)}
+              required={true}
               readOnly={readOnly}
               value={edited?.name ?? ""}
             />
@@ -69,6 +105,18 @@ class PricelistGeneralPanel extends FormPanel {
   }
 }
 
-const enhance = combine(withHistory, withModulesManager, withTheme, withStyles(styles));
+const mapStateToProps = (state) => ({
+  isMedicalServiceValid: state.medical_pricelist.validationFields?.medicalServices?.isValid,
+  isMedicalServiceValidating: state.medical_pricelist.validationFields?.medicalServices?.isValidating,
+  medicalServiceValidationError: state.medical_pricelist.validationFields?.medicalServices?.validationError,
+  savedServiceName: state.medical_pricelist?.pricelists?.services.item?.name,
+  isMedicalItemValid: state.medical_pricelist.validationFields?.medicalItems?.isValid,
+  isMedicalItemValidating: state.medical_pricelist.validationFields?.medicalItems?.isValidating,
+  medicalItemValidationError: state.medical_pricelist.validationFields?.medicalItems?.validationError,
+  savedItemName: state.medical_pricelist?.pricelists?.items.item?.name,
+  activeType: state.medical_pricelist?.services?.type || state.medical_pricelist?.items?.type,
+});
 
-export default enhance(PricelistGeneralPanel);
+export default withHistory(
+  withModulesManager(connect(mapStateToProps)(withTheme(withStyles(styles)(PricelistGeneralPanel))))
+);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -287,7 +287,7 @@ function reducer(
         fetchingPricelist: false,
         errorPricelist: formatServerError(action.payload),
       };
-    case "PRICELIST_SERVICES_VALIDATION_FIELDS_REQ":
+    case "PRICELIST_SERVICES_FIELDS_VALIDATION_REQ":
       return {
         ...state,
         validationFields: {
@@ -299,7 +299,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_SERVICES_VALIDATION_FIELDS_RESP":
+    case "PRICELIST_SERVICES_FIELDS_VALIDATION_RESP":
       return {
         ...state,
         validationFields: {
@@ -311,7 +311,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_SERVICES_VALIDATION_FIELDS_ERR":
+    case "PRICELIST_SERVICES_FIELDS_VALIDATION_ERR":
       return {
         ...state,
         validationFields: {
@@ -323,7 +323,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_SERVICES_VALIDATION_FIELDS_CLEAR":
+    case "PRICELIST_SERVICES_FIELDS_VALIDATION_CLEAR":
       return {
         ...state,
         validationFields: {
@@ -335,7 +335,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_ITEMS_VALIDATION_FIELDS_REQ":
+    case "PRICELIST_ITEMS_FIELDS_VALIDATION_REQ":
       return {
         ...state,
         validationFields: {
@@ -347,7 +347,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_ITEMS_VALIDATION_FIELDS_RESP":
+    case "PRICELIST_ITEMS_FIELDS_VALIDATION_RESP":
       return {
         ...state,
         validationFields: {
@@ -359,7 +359,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_ITEMS_VALIDATION_FIELDS_ERR":
+    case "PRICELIST_ITEMS_FIELDS_VALIDATION_ERR":
       return {
         ...state,
         validationFields: {
@@ -371,7 +371,7 @@ function reducer(
           },
         },
       };
-    case "PRICELIST_ITEMS_VALIDATION_FIELDS_CLEAR":
+    case "PRICELIST_ITEMS_FIELDS_VALIDATION_CLEAR":
       return {
         ...state,
         validationFields: {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,5 @@
 import { formatServerError, formatGraphQLError, parseData, pageInfo } from "@openimis/fe-core";
-import { SERVICES_PRICELIST_TYPE } from "./constants";
+import { SERVICES_PRICELIST_TYPE, ITEMS_PRICELIST_TYPE } from "./constants";
 
 function arrayToMap(arr) {
   return arr.reduce((map, a) => {
@@ -36,11 +36,13 @@ function reducer(
       services: {
         isFetching: false,
         items: {},
+        item: {},
         error: null,
       },
       items: {
         isFetching: false,
         items: {},
+        item: {},
         error: null,
       },
     },
@@ -68,6 +70,10 @@ function reducer(
           isFetching: true,
           error: null,
         },
+        items: {
+          ...state.items,
+          type: null,
+        }
       };
     case "MEDICAL_PRICELIST_SERVICES_RESP":
       const formatService = (service) => {
@@ -87,6 +93,7 @@ function reducer(
           isFetching: false,
           items: parseData(action.payload.data.medicalServices).map(formatService),
           pageInfo: pageInfo(action.payload.data.medicalServices),
+          type: SERVICES_PRICELIST_TYPE,
         },
       };
     case "MEDICAL_PRICELIST_SERVICES_ERR":
@@ -102,11 +109,15 @@ function reducer(
     case "MEDICAL_PRICELIST_ITEMS_REQ":
       return {
         ...state,
-        services: {
-          ...state.services,
+        items: {
+          ...state.items,
           isFetching: true,
           error: null,
         },
+        services: {
+          ...state.services,
+          type: null,
+        }
       };
     case "MEDICAL_PRICELIST_ITEMS_RESP":
       const formatItem = (item) => {
@@ -126,6 +137,7 @@ function reducer(
           isFetching: false,
           items: parseData(action.payload.data.medicalItems).map(formatItem),
           pageInfo: pageInfo(action.payload.data.medicalItems),
+          type: ITEMS_PRICELIST_TYPE,
         },
       };
     case "MEDICAL_PRICELIST_ITEMS_ERR":
@@ -162,6 +174,7 @@ function reducer(
               ...state.pricelists[action.meta.pricelistType].items,
               [action.payload.data.node.id]: action.payload.data.node,
             },
+            item: action.payload.data.node,
           },
         },
       };
@@ -174,6 +187,21 @@ function reducer(
             ...state.pricelists[action.meta.pricelistType],
             isFetching: false,
             error: formatServerError(action.payload),
+          },
+        },
+      };
+    case "MEDICAL_PRICELIST_PRICELIST_CLEAR":
+      return {
+        ...state,
+        pricelists: {
+          ...state.pricelists,
+          services: {
+            ...state.pricelists.services,
+            item: {},
+          },
+          items: {
+            ...state.pricelists.items,
+            item: {},
           },
         },
       };
@@ -258,6 +286,102 @@ function reducer(
         ...state,
         fetchingPricelist: false,
         errorPricelist: formatServerError(action.payload),
+      };
+    case "PRICELIST_SERVICES_VALIDATION_FIELDS_REQ":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalServices: {
+            isValidating: true,
+            isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "PRICELIST_SERVICES_VALIDATION_FIELDS_RESP":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalServices: {
+            isValidating: false,
+            isValid: action.payload?.data.isValid,
+            validationError: formatGraphQLError(action.payload),
+          },
+        },
+      };
+    case "PRICELIST_SERVICES_VALIDATION_FIELDS_ERR":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalServices: {
+            isValidating: false,
+            isValid: false,
+            validationError: formatServerError(action.payload),
+          },
+        },
+      };
+    case "PRICELIST_SERVICES_VALIDATION_FIELDS_CLEAR":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalServices: {
+            isValidating: true,
+            isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "PRICELIST_ITEMS_VALIDATION_FIELDS_REQ":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalItems: {
+            isValidating: true,
+            isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "PRICELIST_ITEMS_VALIDATION_FIELDS_RESP":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalItems: {
+            isValidating: false,
+            isValid: action.payload?.data.isValid,
+            validationError: formatGraphQLError(action.payload),
+          },
+        },
+      };
+    case "PRICELIST_ITEMS_VALIDATION_FIELDS_ERR":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalItems: {
+            isValidating: false,
+            isValid: false,
+            validationError: formatServerError(action.payload),
+          },
+        },
+      };
+    case "PRICELIST_ITEMS_VALIDATION_FIELDS_CLEAR":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalItems: {
+            isValidating: true,
+            isValid: false,
+            validationError: null,
+          },
+        },
       };
     default:
       return state;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -12,6 +12,7 @@
   "medical_pricelist.openNewTab": "Open in a new tab",
   "medical_pricelist.addNewPriceListTooltip": "Add a new pricelist",
   "medical_pricelist.deletePricelistTooltip": "Delete",
+  "medical_pricelist.nameTaken": "Name already taken.",
   "medical_pricelist.pricelistForm.title": "Pricelist ({label})",
   "medical_pricelist.pricelistForm.selectAll": "Select All",
   "medical_pricelist.pricelistForm.table.title": "Details",


### PR DESCRIPTION
PART OF [CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/87)

In scope of this ticket, I implemented the validation of pricelist name. There is not way to change pricelist name to existing one as well as create a new pricelist with name which is already taken (user has an appropriate information about the cause and the save button is disabled).
