### PR TITLE
OTC-884: Disabled save button in price lists forms

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -243,6 +243,12 @@ export function medicalServicesValidationCheck(mm, variables) {
   );
 }
 
+export function medicalServicesSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `PRICELIST_SERVICES_FIELDS_VALIDATION_SET_VALID` });
+  };
+}
+
 export function medicalServicesValidationClear() {
   return (dispatch) => {
     dispatch({ type: `PRICELIST_SERVICES_FIELDS_VALIDATION_CLEAR` });
@@ -264,6 +270,12 @@ export function medicalItemsValidationCheck(mm, variables) {
 export function medicalItemsValidationClear() {
   return (dispatch) => {
     dispatch({ type: `PRICELIST_ITEMS_FIELDS_VALIDATION_CLEAR` });
+  };
+}
+
+export function medicalItemsSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `PRICELIST_ITEMS_FIELDS_VALIDATION_SET_VALID` });
   };
 }
 

--- a/src/components/PricelistGeneralPanel.js
+++ b/src/components/PricelistGeneralPanel.js
@@ -11,8 +11,10 @@ import {
 import {
   medicalServicesValidationCheck,
   medicalServicesValidationClear,
+  medicalServicesSetValid,
   medicalItemsValidationCheck,
   medicalItemsValidationClear,
+  medicalItemsSetValid,
 } from "../actions";
 import { SERVICES_PRICELIST_TYPE } from "../constants";
 
@@ -58,6 +60,7 @@ class PricelistGeneralPanel extends FormPanel {
             <ValidatedTextInput
               action={servicesOrItems ? medicalServicesValidationCheck : medicalItemsValidationCheck}
               clearAction={servicesOrItems ? medicalServicesValidationClear : medicalItemsValidationClear}
+              setValidAction={servicesOrItems ? medicalServicesSetValid : medicalItemsSetValid}
               itemQueryIdentifier={servicesOrItems ? "servicesPricelistName" : "itemsPricelistName"}
               isValid={servicesOrItems ? isMedicalServiceValid : isMedicalItemValid}
               isValidating={servicesOrItems ? isMedicalServiceValidating : isMedicalItemValidating}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -73,7 +73,7 @@ function reducer(
         items: {
           ...state.items,
           type: null,
-        }
+        },
       };
     case "MEDICAL_PRICELIST_SERVICES_RESP":
       const formatService = (service) => {
@@ -117,7 +117,7 @@ function reducer(
         services: {
           ...state.services,
           type: null,
-        }
+        },
       };
     case "MEDICAL_PRICELIST_ITEMS_RESP":
       const formatItem = (item) => {
@@ -335,6 +335,18 @@ function reducer(
           },
         },
       };
+    case "PRICELIST_SERVICES_FIELDS_VALIDATION_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalServices: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
     case "PRICELIST_ITEMS_FIELDS_VALIDATION_REQ":
       return {
         ...state,
@@ -379,6 +391,18 @@ function reducer(
           medicalItems: {
             isValidating: true,
             isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "PRICELIST_ITEMS_FIELDS_VALIDATION_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          medicalItems: {
+            isValidating: false,
+            isValid: true,
             validationError: null,
           },
         },


### PR DESCRIPTION
[OTC-884](https://openimis.atlassian.net/browse/OTC-884)

In scope of this ticket, I corrected the state of isValid by adding an extra action, which sets the state properly when we're editing a name of services/items price lists for the first time. Moreover, there was an issue when we paste an invalid name and then revert it using CTRL+Z to the valid one, save button was anyway blocked although saving should be possbile. After the fix, it works as intended.

[OTC-884]: https://openimis.atlassian.net/browse/OTC-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ