### PR TITLE
OTC-757: Clearing pagination page if entered the IPPage or SPPage

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -10,3 +10,4 @@ export const RIGHT_ITEMS_PRICELISTS_DELETE = 121304;
 export const RIGHT_ITEMS_PRICELISTS_DUPLICATE = 121305;
 export const SERVICES_PRICELIST_TYPE = "services";
 export const ITEMS_PRICELIST_TYPE = "items";
+export const MODULE_NAME = "medical_pricelist";

--- a/src/pages/ItemsPricelistsPage.js
+++ b/src/pages/ItemsPricelistsPage.js
@@ -1,9 +1,17 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import { withHistory, historyPush, combine, withModulesManager, useTranslations, withTooltip } from "@openimis/fe-core";
+import {
+  withHistory,
+  historyPush,
+  combine,
+  withModulesManager,
+  useTranslations,
+  withTooltip,
+  clearCurrentPaginationPage,
+} from "@openimis/fe-core";
 import PricelistsSearcher from "../components/PricelistsSearcher";
 import { fetchItemsPricelistsSummaries, deleteItemsPricelist } from "../actions";
 import { RIGHT_ITEMS_PRICELISTS_DELETE, RIGHT_ITEMS_PRICELISTS_ADD } from "../constants";
@@ -20,6 +28,7 @@ const ItemsPricelistsPage = (props) => {
   const { classes, modulesManager, history } = props;
   const { formatMessage, formatMessageWithValues } = useTranslations("medical_pricelist", modulesManager);
   const rights = useSelector((state) => state.core.user?.i_user?.rights ?? []);
+  const module = useSelector((state) => state.core?.savedPagination?.module);
   const data = useSelector((state) => state.medical_pricelist.summaries.items);
   const dispatch = useDispatch();
   const onDoubleClick = (row, newTab = false) => {
@@ -43,6 +52,21 @@ const ItemsPricelistsPage = (props) => {
       )
     );
   };
+
+  useEffect(() => {
+    const moduleName = "medical_pricelist";
+    if (module !== moduleName) dispatch(clearCurrentPaginationPage());
+
+    return () => {
+      const { location, history } = props;
+      const {
+        location: { pathname },
+      } = history;
+      const urlPath = location.pathname;
+
+      if (!pathname.includes(urlPath)) dispatch(clearCurrentPaginationPage());
+    };
+  }, [module]);
 
   return (
     <div className={classes.page}>

--- a/src/pages/ItemsPricelistsPage.js
+++ b/src/pages/ItemsPricelistsPage.js
@@ -14,7 +14,7 @@ import {
 } from "@openimis/fe-core";
 import PricelistsSearcher from "../components/PricelistsSearcher";
 import { fetchItemsPricelistsSummaries, deleteItemsPricelist } from "../actions";
-import { RIGHT_ITEMS_PRICELISTS_DELETE, RIGHT_ITEMS_PRICELISTS_ADD } from "../constants";
+import { RIGHT_ITEMS_PRICELISTS_DELETE, RIGHT_ITEMS_PRICELISTS_ADD, MODULE_NAME} from "../constants";
 
 const styles = (theme) => ({
   page: {
@@ -54,8 +54,7 @@ const ItemsPricelistsPage = (props) => {
   };
 
   useEffect(() => {
-    const moduleName = "medical_pricelist";
-    if (module !== moduleName) dispatch(clearCurrentPaginationPage());
+    if (module !== MODULE_NAME) dispatch(clearCurrentPaginationPage());
 
     return () => {
       const { location, history } = props;

--- a/src/pages/ServicesPricelistsPage.js
+++ b/src/pages/ServicesPricelistsPage.js
@@ -14,7 +14,7 @@ import {
 } from "@openimis/fe-core";
 import PricelistsSearcher from "../components/PricelistsSearcher";
 import { fetchServicesPricelistsSummaries, deleteServicesPricelist } from "../actions";
-import { RIGHT_SERVICES_PRICELISTS_DELETE, RIGHT_SERVICES_PRICELISTS_ADD } from "../constants";
+import { RIGHT_SERVICES_PRICELISTS_DELETE, RIGHT_SERVICES_PRICELISTS_ADD, MODULE_NAME } from "../constants";
 
 const styles = (theme) => ({
   page: theme.page,
@@ -52,8 +52,7 @@ const ServicesPricelistsPage = (props) => {
   };
 
   useEffect(() => {
-    const moduleName = "medical_pricelist";
-    if (module !== moduleName) dispatch(clearCurrentPaginationPage());
+    if (module !== MODULE_NAME) dispatch(clearCurrentPaginationPage());
 
     return () => {
       const { location, history } = props;

--- a/src/pages/ServicesPricelistsPage.js
+++ b/src/pages/ServicesPricelistsPage.js
@@ -1,9 +1,17 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
-import { withHistory, historyPush, combine, withModulesManager, useTranslations, withTooltip } from "@openimis/fe-core";
+import {
+  withHistory,
+  historyPush,
+  combine,
+  withModulesManager,
+  useTranslations,
+  withTooltip,
+  clearCurrentPaginationPage,
+} from "@openimis/fe-core";
 import PricelistsSearcher from "../components/PricelistsSearcher";
 import { fetchServicesPricelistsSummaries, deleteServicesPricelist } from "../actions";
 import { RIGHT_SERVICES_PRICELISTS_DELETE, RIGHT_SERVICES_PRICELISTS_ADD } from "../constants";
@@ -17,6 +25,7 @@ const ServicesPricelistsPage = (props) => {
   const { classes, modulesManager, history } = props;
   const { formatMessage, formatMessageWithValues } = useTranslations("medical_pricelist", modulesManager);
   const rights = useSelector((state) => state.core.user?.i_user?.rights ?? []);
+  const module = useSelector((state) => state.core?.savedPagination?.module);
   const data = useSelector((state) => state.medical_pricelist.summaries.services);
   const dispatch = useDispatch();
 
@@ -41,6 +50,21 @@ const ServicesPricelistsPage = (props) => {
       )
     );
   };
+
+  useEffect(() => {
+    const moduleName = "medical_pricelist";
+    if (module !== moduleName) dispatch(clearCurrentPaginationPage());
+
+    return () => {
+      const { location, history } = props;
+      const {
+        location: { pathname },
+      } = history;
+      const urlPath = location.pathname;
+
+      if (!pathname.includes(urlPath)) dispatch(clearCurrentPaginationPage());
+    };
+  }, [module]);
 
   return (
     <div className={classes.page}>


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:

- Clearing pagination state if entered the ItemsPricelistsPage or ServicesPricelistsPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.
- Implementation of additional condition which solves an issue when there were more than 1 pagination in a single module.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ