### PR TITLE
OP-1437: Block saving/editing historical data

### DIFF
--- a/src/components/PricelistForm.js
+++ b/src/components/PricelistForm.js
@@ -22,7 +22,8 @@ const PricelistForm = (props) => {
     isValid,
     clearMedicalPricelists,
   } = props;
-  const canSave = () => pricelist.name && pricelist.pricelistDate && isValid === true;
+
+  const canSave = () => pricelist.name && pricelist.pricelistDate && !pricelist.validityTo && isValid === true;
 
   useEffect(() => {
     return () => {

--- a/src/pages/ItemsPricelistDetailsPage.js
+++ b/src/pages/ItemsPricelistDetailsPage.js
@@ -38,8 +38,6 @@ const ItemsPriceListDetailsPage = (props) => {
   const [resetKey, setResetKey] = useState(null);
   const [pricelist, setPricelist] = useState({});
 
-  console.log(pricelist);
-
   useEffect(() => {
     if (match.params.price_list_id) {
       fetchItemsPricelistById(modulesManager, match.params.price_list_id);

--- a/src/pages/ItemsPricelistDetailsPage.js
+++ b/src/pages/ItemsPricelistDetailsPage.js
@@ -38,6 +38,8 @@ const ItemsPriceListDetailsPage = (props) => {
   const [resetKey, setResetKey] = useState(null);
   const [pricelist, setPricelist] = useState({});
 
+  console.log(pricelist);
+
   useEffect(() => {
     if (match.params.price_list_id) {
       fetchItemsPricelistById(modulesManager, match.params.price_list_id);
@@ -79,7 +81,7 @@ const ItemsPriceListDetailsPage = (props) => {
   };
 
   return (
-    <div className={clsx(classes.page, { [classes.locked]: isLocked })}>
+    <div className={clsx(classes.page, pricelist.validityTo && classes.locked)}>
       <ErrorBoundary>
         <ProgressOrError progress={isFetching} error={error} />
         {!isFetching && (

--- a/src/pages/ServicesPricelistDetailsPage.js
+++ b/src/pages/ServicesPricelistDetailsPage.js
@@ -79,7 +79,7 @@ const ServicesPriceListDetailsPage = (props) => {
   };
 
   return (
-    <div className={clsx(classes.page, { [classes.locked]: isLocked })}>
+    <div className={clsx(classes.page, pricelist.validityTo && classes.locked)}>
       <ErrorBoundary>
         <ProgressOrError progress={isFetching} error={error} />
         {!isFetching && (


### PR DESCRIPTION
[OP-1437](https://openimis.atlassian.net/browse/OP-1437)

RELATED [BE PR](https://github.com/openimis/openimis-be-medical_pricelist_py/pull/27)

Changes:
- Saving/editing a historical data not possible.
- LockedPage styles implemented when user is overviewing historical content.

[OP-1437]: https://openimis.atlassian.net/browse/OP-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ