### PR TITLE
OP-1725: remove empty/null option from dropdown

### DIFF
--- a/src/components/PricelistGeneralPanel.js
+++ b/src/components/PricelistGeneralPanel.js
@@ -80,7 +80,7 @@ class PricelistGeneralPanel extends FormPanel {
               pubRef="location.RegionPicker"
               value={region}
               readOnly={readOnly}
-              withNull={true}
+              withNull={false}
               onChange={this.onRegionChange}
             />
           </Grid>
@@ -89,7 +89,7 @@ class PricelistGeneralPanel extends FormPanel {
               region={region}
               value={district}
               pubRef="location.DistrictPicker"
-              withNull={true}
+              withNull={false}
               readOnly={readOnly}
               onChange={this.onDistrictChange}
             />


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ