### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/PricelistsSearcher.js
+++ b/src/components/PricelistsSearcher.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 
-import { Tooltip, IconButton } from "@material-ui/core";
+import { Tooltip, Button } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Tab as TabIcon, Delete as DeleteIcon } from "@material-ui/icons";
 
@@ -70,15 +70,15 @@ const PricelistsSearcher = (props) => {
       (pricelist) => (
         <div className={classes.horizontalButtonContainer}>
           <Tooltip title={formatMessage("openNewTab")}>
-            <IconButton onClick={() => onDoubleClick(pricelist, true)}>
-              <TabIcon />
-            </IconButton>
+            <Button startIcon={<TabIcon />} onClick={() => onDoubleClick(pricelist, true)}>
+              {formatMessage("openNewTabButton.buttonText")}
+            </Button>
           </Tooltip>
           {canDelete(pricelist) && (
             <Tooltip title={formatMessage("deletePricelistTooltip")}>
-              <IconButton onClick={() => setPricelistToDelete(pricelist)}>
-                <DeleteIcon />
-              </IconButton>
+              <Button startIcon={<DeleteIcon />} onClick={() => setPricelistToDelete(pricelist)}>
+                {formatMessage("deletePricelistButton.buttonText")}
+              </Button>
             </Tooltip>
           )}
         </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10,6 +10,8 @@
   "medical_pricelist.valid_from": "Valid From",
   "medical_pricelist.valid_to": "Valid To",
   "medical_pricelist.openNewTab": "Open in a new tab",
+  "medical_pricelist.openNewTabButton.buttonText": "Open",
+  "medical_pricelist.deletePricelistButton.buttonText": "Delete",
   "medical_pricelist.addNewPriceListTooltip": "Add a new pricelist",
   "medical_pricelist.deletePricelistTooltip": "Delete",
   "medical_pricelist.nameTaken": "Name already taken.",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.