### PR TITLE
fix PricelistPicker OP-2788

### DIFF
--- a/src/pickers/ItemsPricelistPicker.js
+++ b/src/pickers/ItemsPricelistPicker.js
@@ -7,7 +7,7 @@ import PricelistPicker from "./PricelistPicker";
 
 class ItemsPricelistPicker extends Component {
   render() {
-    const { name, value, onChange, readOnly, region, district } = this.props;
+    const { name, value, onChange, readOnly, region, district, reload } = this.props;
     return (
       <PricelistPicker
         label="itemsPricelist"
@@ -19,6 +19,7 @@ class ItemsPricelistPicker extends Component {
         onChange={onChange}
         region={region}
         district={district}
+        reload={reload}
       />
     );
   }

--- a/src/pickers/PricelistPicker.js
+++ b/src/pickers/PricelistPicker.js
@@ -41,7 +41,7 @@ class PricelistPicker extends Component {
     if (prevProps.withNull !== this.props.withNull) {
       this.setState((state, props) => ({ baseOptions: props.withNull ? [this._nullOption] : [] }));
     }
-    if (!_.isEqual(prevProps.region, this.props.region)) {
+    if (!_.isEqual(prevProps, this.props)) {
       if (!this.props.region) {
         this.setState({ regionOptions: [] });
       } else {
@@ -57,7 +57,7 @@ class PricelistPicker extends Component {
         );
       }
     }
-    if (!_.isEqual(prevProps.district, this.props.district)) {
+    if (!_.isEqual(prevProps, this.props)) {
       if (!this.props.district) {
         this.setState({ districtOptions: [] });
       } else {

--- a/src/pickers/PricelistPicker.js
+++ b/src/pickers/PricelistPicker.js
@@ -41,23 +41,34 @@ class PricelistPicker extends Component {
     if (prevProps.withNull !== this.props.withNull) {
       this.setState((state, props) => ({ baseOptions: props.withNull ? [this._nullOption] : [] }));
     }
-    if (!_.isEqual(prevProps, this.props)) {
+    const propsToCheck = [
+      "region",
+      "district",
+      "reload",
+    ];
+    
+    const hasChanged = propsToCheck.some(
+      (key) => !_.isEqual(prevProps[key], this.props[key])
+    );
+    
+    if (hasChanged) {
       if (!this.props.region) {
         this.setState({ regionOptions: [] });
       } else {
-        this.setState({ loading: true }, (e) =>
-          this.props.fetchPriceLists(this.props.region).then(
-            (r) =>
-              this._isMounted &&
+        this.setState({ loading: true }, () => {
+          this.props.fetchPriceLists(this.props.region).then((r) => {
+            if (this._isMounted) {
               this.setState((state, props) => ({
                 loading: false,
                 regionOptions: parseData(r.payload.data[props.parseKey]).map(this.formatOption),
-              }))
-          )
-        );
+              }));
+            }
+          });
+        });
       }
     }
-    if (!_.isEqual(prevProps, this.props)) {
+    
+    if (hasChanged) {
       if (!this.props.district) {
         this.setState({ districtOptions: [] });
       } else {

--- a/src/pickers/ServicesPricelistPicker.js
+++ b/src/pickers/ServicesPricelistPicker.js
@@ -6,7 +6,7 @@ import { fetchServicesPriceLists } from "../actions";
 import PricelistPicker from "./PricelistPicker";
 
 const ServicesPricelistPicker = (props) => {
-  const { fetchServicesPriceLists, name, value, onChange, readOnly, region, district } = props;
+  const { fetchServicesPriceLists, name, value, onChange, readOnly, region, district, reload } = props;
   return (
     <PricelistPicker
       label="servicesPricelist"
@@ -18,6 +18,7 @@ const ServicesPricelistPicker = (props) => {
       onChange={onChange}
       region={region}
       district={district}
+      reload={reload}
     />
   );
 };


### PR DESCRIPTION
When you click on reload button in the FOSA form, and it's reloaded, Pricelist options of district and region is no longer retrieved in the PricelistPicker component. We have proposed a solution to this problem

this PR is linked up with https://github.com/openimis/openimis-fe-location_js/pull/99 and both work together.

The problem here arose when the "reload" button on the form was clicked. The regional and district lists were no longer being retrieved because the conditions in the ComponentDidUpdate block weren't sufficient to trigger the refetch. So I added a "reload" prop, meaning the change will be detected each time the form is reloaded and will trigger the refetching of the lists in ComponentDidUpdate.

It is also necessary to ensure that the locations(region & district) in the price list correspond to those of the FOSA to which it is to be assigned, as there is a filter that applies.

<img width="1422" height="388" alt="Capture d’écran du 2025-10-31 15-13-59" src="https://github.com/user-attachments/assets/e234ddf6-1c99-4c37-83f3-2ac2bc6d3f8c" />
<img width="422" height="146" alt="Capture d’écran du 2025-10-31 15-14-19" src="https://github.com/user-attachments/assets/8648cf3a-7646-4312-90af-f0f1788feaa5" />