### PR TITLE
OP-2795: set a pickerNoOptionsLabel props in PricelistPicker

### DIFF
--- a/src/pickers/PricelistPicker.js
+++ b/src/pickers/PricelistPicker.js
@@ -100,7 +100,6 @@ class PricelistPicker extends Component {
         options={this.filterOptions(options)}
         name={name}
         value={value}
-        pickerNoOptionsLabel={formatMessage(this.props.intl, "medical_pricelist", "pickerNoOptionsLabel")}
         readOnly={readOnly}
         onChange={onChange}
       />

--- a/src/pickers/PricelistPicker.js
+++ b/src/pickers/PricelistPicker.js
@@ -100,7 +100,7 @@ class PricelistPicker extends Component {
         options={this.filterOptions(options)}
         name={name}
         value={value}
-        noOptionsText={formatMessage(this.props.intl, "medical_pricelist", "noOptionsText")}
+        pickerNoOptionsLabel={formatMessage(this.props.intl, "medical_pricelist", "pickerNoOptionsLabel")}
         readOnly={readOnly}
         onChange={onChange}
       />

--- a/src/pickers/PricelistPicker.js
+++ b/src/pickers/PricelistPicker.js
@@ -100,6 +100,7 @@ class PricelistPicker extends Component {
         options={this.filterOptions(options)}
         name={name}
         value={value}
+        noOptionsText={formatMessage(this.props.intl, "medical_pricelist", "noOptionsText")}
         readOnly={readOnly}
         onChange={onChange}
       />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "pickerNoOptionsLabel": "No options available(no pricelist has a matching location)",
+  "medical_pricelist.pickerNoOptionsLabel": "No options available(no pricelist has a matching location)",
   "medical_pricelist.servicesPricelist": "Services Pricelist",
   "medical_pricelist.itemsPricelist": "Items Pricelist",
   "medical_pricelist.pricelistsSearcher.table.title": "{count} Pricelists",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "noOptionsText": "No options available(no pricelist has a matching location)",
   "medical_pricelist.servicesPricelist": "Services Pricelist",
   "medical_pricelist.itemsPricelist": "Items Pricelist",
   "medical_pricelist.pricelistsSearcher.table.title": "{count} Pricelists",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "noOptionsText": "No options available(no pricelist has a matching location)",
+  "pickerNoOptionsLabel": "No options available(no pricelist has a matching location)",
   "medical_pricelist.servicesPricelist": "Services Pricelist",
   "medical_pricelist.itemsPricelist": "Items Pricelist",
   "medical_pricelist.pricelistsSearcher.table.title": "{count} Pricelists",


### PR DESCRIPTION
we have set a No Options Label props in the PricelistPicker to show appropriate message when there is no pricelists to show to user. this PR is linked up with https://github.com/openimis/openimis-fe-core_js/pull/293. 

this props can be useful in all others components using component SelectInput as child.