### PR TITLE
Fix typo in package.json: peerDependency -> peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start": "rollup -c -w",
     "prepare":"npm run build"
   },
-  "peerDependency": {
+  "peerDependencies": {
     "react-intl": "^5.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### What was changed
Fixed a typo in `package.json` where `peerDependency` was used instead of the correct `peerDependencies` field.

### Why this change
`peerDependency` is not a valid npm/Yarn field and is ignored by package managers. As a result, peer dependency constraints were not being applied correctly, leading to warnings and inconsistent dependency resolution in Yarn.

Note: This same fix was applied across multiple frontend modules. All related PRs are identical.