### PR TITLE
refactor(pricelist): switch from ID-based to UUID-based pricelist fet…

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,14 +1,15 @@
 import {
   graphql,
   formatQuery,
-  formatNodeQuery,
   formatPageQueryWithCount,
   formatPageQuery,
   decodeId,
+  formatGQLString,
   graphqlMutation,
   graphqlWithVariables,
 } from "@openimis/fe-core";
 import { ITEMS_PRICELIST_TYPE, SERVICES_PRICELIST_TYPE } from "./constants";
+import { normalizePrice } from "./helpers/pricelist";
 
 export function fetchPriceLists(servicesPricelist, itemsPricelist) {
   let filters = [];
@@ -32,7 +33,7 @@ export function fetchPriceLists(servicesPricelist, itemsPricelist) {
   });
 }
 
-const PRICELIST_BY_ID_PROJECTIONS = [
+const PRICELIST_PROJECTIONS = [
   "id",
   "uuid",
   "name",
@@ -43,14 +44,22 @@ const PRICELIST_BY_ID_PROJECTIONS = [
   "location{id,name,uuid,code,type,parent{id,uuid,code,name,type}}",
 ];
 
-export function fetchServicesPricelistById(mm, pricelistId) {
-  const query = formatNodeQuery("ServicesPricelistGQLType", pricelistId, PRICELIST_BY_ID_PROJECTIONS);
-  return graphql(query, "MEDICAL_PRICELIST_PRICELIST", { pricelistType: SERVICES_PRICELIST_TYPE });
+export function fetchServicesPricelistByUuid(mm, pricelistUuid) {
+  const query = formatPageQuery(
+    "servicesPricelists",
+    [`uuid: "${formatGQLString(pricelistUuid)}"`],
+    PRICELIST_PROJECTIONS
+  );
+  return graphql(query, "MEDICAL_PRICELIST_PRICELIST", { pricelistType: SERVICES_PRICELIST_TYPE, pricelistUuid });
 }
 
-export function fetchItemsPricelistById(mm, pricelistId) {
-  const query = formatNodeQuery("ItemsPricelistGQLType", pricelistId, PRICELIST_BY_ID_PROJECTIONS);
-  return graphql(query, "MEDICAL_PRICELIST_PRICELIST", { pricelistType: ITEMS_PRICELIST_TYPE });
+export function fetchItemsPricelistByUuid(mm, pricelistUuid) {
+  const query = formatPageQuery(
+    "itemsPricelists",
+    [`uuid: "${formatGQLString(pricelistUuid)}"`],
+    PRICELIST_PROJECTIONS
+  );
+  return graphql(query, "MEDICAL_PRICELIST_PRICELIST", { pricelistType: ITEMS_PRICELIST_TYPE, pricelistUuid });
 }
 
 export function fetchServicesPriceLists(location) {
@@ -133,7 +142,10 @@ function prepareInput(pricelist) {
     addedDetails: pricelist.addedDetails,
     removedDetails: pricelist.removedDetails,
     priceOverrules: pricelist.priceOverrules
-      ? Object.entries(pricelist.priceOverrules).map(([uuid, price]) => ({ uuid, price }))
+      ? Object.entries(pricelist.priceOverrules).map(([uuid, price]) => ({
+          uuid,
+          price: normalizePrice(price),
+        }))
       : undefined,
   };
 }
@@ -239,7 +251,7 @@ export function medicalServicesValidationCheck(mm, variables) {
     }
     `,
     variables,
-    `PRICELIST_SERVICES_FIELDS_VALIDATION`,
+    `PRICELIST_SERVICES_FIELDS_VALIDATION`
   );
 }
 
@@ -263,7 +275,7 @@ export function medicalItemsValidationCheck(mm, variables) {
     }
     `,
     variables,
-    `PRICELIST_ITEMS_FIELDS_VALIDATION`,
+    `PRICELIST_ITEMS_FIELDS_VALIDATION`
   );
 }
 

--- a/src/components/PriceOverruleDialog.jsx
+++ b/src/components/PriceOverruleDialog.jsx
@@ -1,16 +1,27 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { styled } from "@mui/material/styles";
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
-import { combine, FormattedMessage, NumberInput } from "@openimis/fe-core";
+import { combine, FormattedMessage, AmountInput } from "@openimis/fe-core";
 
-const StyledPriceOverruleDialog = styled('div')(({ theme }) => ({
-  '& .primaryButton': theme.dialog?.primaryButton ?? {},
-  '& .secondaryButton': theme.dialog?.secondaryButton ?? {},
+const parsePriceValue = (price) => {
+  if (price == null || price === "") return null;
+  const num = Number(price);
+  return Number.isNaN(num) ? null : num;
+};
+
+const StyledPriceOverruleDialog = styled("div")(({ theme }) => ({
+  "& .primaryButton": theme.dialog?.primaryButton ?? {},
+  "& .secondaryButton": theme.dialog?.secondaryButton ?? {},
 }));
 
 const PriceOverruleDialog = (props) => {
   const { open, onCancel, defaultPrice, onConfirm } = props;
-  const [value, setValue] = useState(defaultPrice);
+  const [value, setValue] = useState(() => parsePriceValue(defaultPrice));
+
+  useEffect(() => {
+    setValue(parsePriceValue(defaultPrice));
+  }, [defaultPrice]);
+
   return (
     <StyledPriceOverruleDialog>
       <Dialog open={open} onClose={onCancel}>
@@ -21,7 +32,7 @@ const PriceOverruleDialog = (props) => {
           <DialogContentText>
             <FormattedMessage module="medical_pricelist" id="priceOverruleDialog.message" />
           </DialogContentText>
-          <NumberInput
+          <AmountInput
             autoFocus
             margin="dense"
             id="price"
@@ -37,7 +48,7 @@ const PriceOverruleDialog = (props) => {
           <Button onClick={(e) => onConfirm(value)} className="primaryButton" autoFocus>
             <FormattedMessage module="medical_pricelist" id="priceOverruleDialog.yes.button" />
           </Button>
-          <Button onClick={(e) => onConfirm(null)} className="secondaryButton" autoFocus>
+          <Button onClick={(e) => onConfirm(null)} className="secondaryButton">
             <FormattedMessage module="medical_pricelist" id="priceOverruleDialog.clear.button" />
           </Button>
           <Button onClick={onCancel} className="secondaryButton">

--- a/src/components/PricelistDetailsPanel.jsx
+++ b/src/components/PricelistDetailsPanel.jsx
@@ -1,35 +1,42 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { styled } from "@mui/material/styles";
 import { Table, withModulesManager, combine, useTranslations, ErrorBoundary } from "@openimis/fe-core";
-import { Paper, Grid, Typography, Checkbox, Button} from "@mui/material";
+import { Paper, Grid, Typography, Checkbox, Button } from "@mui/material";
 import PriceOverruleDialog from "./PriceOverruleDialog";
-import SelectAllButton from "./PricelistSelectAllButton" 
+import SelectAllButton from "./PricelistSelectAllButton";
+import { isItemActive } from "../helpers/selection";
 
-const StyledPricelistDetailsPanel = styled('div')(({ theme }) => ({
-  '& .paper': theme.paper?.paper ?? {},
-  '& .item': theme.paper?.item ?? {},
-  '& .tableTitle': theme.table?.title ?? {},
-  '& .checkbox': {
+const StyledPricelistDetailsPanel = styled("div")(({ theme }) => ({
+  "& .paper": theme.paper?.paper ?? {},
+  "& .item": theme.paper?.item ?? {},
+  "& .tableTitle": theme.table?.title ?? {},
+  "& .table": {
+    tableLayout: "fixed",
+    width: "100%",
+  },
+  "& .table .MuiTableCell-root": {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  "& .table .MuiTableCell-root:nth-of-type(1)": {
+    width: "6rem",
+  },
+  "& .checkbox": {
     padding: theme.spacing(0),
   },
-  '& .editDetailBtn': {
+  "& .selectAllBtn": {
+    minWidth: "4.5rem",
+  },
+  "& .editDetailBtn": {
     padding: 0,
+    minWidth: "auto",
+  },
+  "& .editDetailCell": {
+    width: "4rem",
+    textAlign: "right",
   },
 }));
-
-const HEADERS = [
-  "",
-  "medical_pricelist.table.code",
-  "medical_pricelist.table.name",
-  "medical_pricelist.table.type",
-  "medical_pricelist.table.price",
-  "medical_pricelist.table.overrule",
-  "",
-];
-
-const isItemActive = (edited, item) => {
-  return edited.addedDetails?.includes(item.uuid) || (item.isActive && !edited.removedDetails?.includes(item.uuid));
-};
 
 const PricelistDetailsPanel = (props) => {
   const {
@@ -41,16 +48,46 @@ const PricelistDetailsPanel = (props) => {
     details,
     fetchDetails,
     onEditedChanged,
+    detailsRefreshKey = 0,
   } = props;
-  const { formatMessage } = useTranslations("medical_pricelist", modulesManager);
+  const { formatMessage, formatAmount } = useTranslations("medical_pricelist", modulesManager);
+
+  const formatPrice = (price) => (price != null && price !== "" ? formatAmount(price) : "");
+
+  const getListPrice = (item) => {
+    if (edited.priceOverrules && item.uuid in edited.priceOverrules) {
+      return edited.priceOverrules[item.uuid];
+    }
+    return item.priceOverrule;
+  };
   const [pagination, setPagination] = useState({ page: 0, afterCursor: null, beforeCursor: null });
   const [editedDetail, setEditedDetail] = useState(null);
-  
-  const ButtonHeader = (_) => {
-    return SelectAllButton(details, props, edited, onEditedChanged, edited)
-  }
 
-  HEADERS[0] = ButtonHeader
+  const renderSelectAllHeader = useCallback(
+    () => (
+      <SelectAllButton
+        details={details}
+        readOnly={readOnly}
+        edited={edited}
+        onEditedChanged={onEditedChanged}
+        modulesManager={modulesManager}
+      />
+    ),
+    [details, readOnly, edited, onEditedChanged, modulesManager]
+  );
+
+  const headers = useMemo(
+    () => [
+      renderSelectAllHeader,
+      "medical_pricelist.table.code",
+      "medical_pricelist.table.name",
+      "medical_pricelist.table.type",
+      "medical_pricelist.table.price",
+      "medical_pricelist.table.overrule",
+      "",
+    ],
+    [renderSelectAllHeader]
+  );
 
   useEffect(() => {
     const filters = [];
@@ -63,7 +100,7 @@ const PricelistDetailsPanel = (props) => {
     }
 
     fetchDetails(filters);
-  }, [pagination.page, edited_id]);
+  }, [pagination.page, edited_id, detailsRefreshKey]);
 
   const onDetailChange = (event, item) => {
     if (event.target.checked) {
@@ -71,12 +108,12 @@ const PricelistDetailsPanel = (props) => {
         ...edited,
         // It's useless to add the to the list of added items if it is already marked as active
         addedDetails: !item.isActive ? (edited.addedDetails ?? []).concat(item.uuid) : edited.addedDetails,
-        removedDetails: edited.removedDetails && edited.removedDetails.filter((x) => x !== item.uuid),
+        removedDetails: (edited.removedDetails ?? []).filter((x) => x !== item.uuid),
       });
     } else {
       onEditedChanged({
         ...edited,
-        addedDetails: edited.addedDetails && edited.addedDetails.filter((x) => x !== item.uuid),
+        addedDetails: (edited.addedDetails ?? []).filter((x) => x !== item.uuid),
         removedDetails: item.isActive ? (edited.removedDetails ?? []).concat([item.uuid]) : edited.removedDetails,
       });
     }
@@ -122,7 +159,7 @@ const PricelistDetailsPanel = (props) => {
               <Table
                 error={details.error}
                 fetching={details.isFetching}
-                headers={HEADERS}
+                headers={headers}
                 itemFormatters={[
                   (s) => (
                     <Checkbox
@@ -136,23 +173,25 @@ const PricelistDetailsPanel = (props) => {
                   (s) => s.code,
                   (s) => s.name,
                   (s) => formatMessage(`medical_pricelist.table.type.${s.type.toLowerCase()}`),
-                  (s) => s.price,
-                  (s) => s.priceOverrule,
-                  (s) =>
-                    isItemActive(edited, s) &&
-                    !readOnly && (
-                      <Button
-                        size="small"
-                        variant="text"
-                        color="primary"
-                        className="editDetailBtn"
-                        onClick={() => setEditedDetail(s)}
-                      >
-                        {formatMessage("medical_pricelist.table.editOverruleButton")}
-                      </Button>
-                    ),
+                  (s) => formatPrice(s.price),
+                  (s) => formatPrice(getListPrice(s)),
+                  (s) => (
+                    <span className="editDetailCell">
+                      {isItemActive(edited, s) && !readOnly && (
+                        <Button
+                          size="small"
+                          variant="text"
+                          color="primary"
+                          className="editDetailBtn"
+                          onClick={() => setEditedDetail(s)}
+                        >
+                          {formatMessage("medical_pricelist.table.editOverruleButton")}
+                        </Button>
+                      )}
+                    </span>
+                  ),
                 ]}
-                aligns={HEADERS.map((_, i) => (i === HEADERS.length - 1 ? "right" : null))}
+                aligns={headers.map((_, i) => (i >= headers.length - 3 ? "right" : null))}
                 items={details.items}
                 withPagination
                 page={pagination.page}

--- a/src/components/PricelistForm.jsx
+++ b/src/components/PricelistForm.jsx
@@ -2,12 +2,12 @@ import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 
-
 import { GetIconComponent, withHistory, withModulesManager, Form } from "@openimis/fe-core";
 import { clearMedicalPricelists } from "../actions";
+import { SERVICES_PRICELIST_TYPE, ITEMS_PRICELIST_TYPE } from "../constants";
 import PricelistGeneralPanel from "./PricelistGeneralPanel";
 import PricelistDetailsPanel from "./PricelistDetailsPanel";
-const ReplayIcon = GetIconComponent("Replay")
+const ReplayIcon = GetIconComponent("Replay");
 
 const PricelistForm = (props) => {
   const {
@@ -19,8 +19,12 @@ const PricelistForm = (props) => {
     onChange,
     fetchDetails,
     details,
+    detailsRefreshKey,
     isValid,
     clearMedicalPricelists,
+    reset,
+    pricelistType,
+    originalName,
   } = props;
 
   const canSave = () => pricelist.name && pricelist.pricelistDate && !pricelist.validityTo && isValid === true;
@@ -48,7 +52,11 @@ const PricelistForm = (props) => {
         onEditedChanged={onChange}
         details={details}
         fetchDetails={fetchDetails}
-        openDirty={onSave}
+        detailsRefreshKey={detailsRefreshKey}
+        reset={reset}
+        pricelistType={pricelistType}
+        originalName={originalName}
+        openDirty={!pricelist?.uuid}
         actions={[
           {
             doIt: onReset,
@@ -61,11 +69,17 @@ const PricelistForm = (props) => {
   );
 };
 
-const mapStateToProps = (state) => ({
-  isValid:
-    !!state.medical_pricelist.validationFields?.medicalServices?.isValid ||
-    !!state.medical_pricelist.validationFields?.medicalItems?.isValid,
-});
+const mapStateToProps = (state, ownProps) => {
+  const validationFields = state.medical_pricelist.validationFields;
+  const isValid =
+    ownProps.pricelistType === SERVICES_PRICELIST_TYPE
+      ? !!validationFields?.medicalServices?.isValid
+      : ownProps.pricelistType === ITEMS_PRICELIST_TYPE
+        ? !!validationFields?.medicalItems?.isValid
+        : !!validationFields?.medicalServices?.isValid || !!validationFields?.medicalItems?.isValid;
+
+  return { isValid };
+};
 
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators({ clearMedicalPricelists }, dispatch);

--- a/src/components/PricelistGeneralPanel.jsx
+++ b/src/components/PricelistGeneralPanel.jsx
@@ -15,15 +15,21 @@ import {
   useDebounceCb,
   GRID_RESPONSIVE_STANDARD,
 } from "@openimis/fe-core";
-import {
-  medicalServicesValidationCheck,
-  medicalServicesValidationClear,
-  medicalServicesSetValid,
-  medicalItemsValidationCheck,
-  medicalItemsValidationClear,
-  medicalItemsSetValid,
-} from "../actions";
-import { SERVICES_PRICELIST_TYPE } from "../constants";
+import * as pricelistActions from "../actions";
+import { SERVICES_PRICELIST_TYPE, ITEMS_PRICELIST_TYPE } from "../constants";
+
+const PRICELIST_VALIDATION_ACTIONS = {
+  [SERVICES_PRICELIST_TYPE]: {
+    check: pricelistActions.medicalServicesValidationCheck,
+    clear: pricelistActions.medicalServicesValidationClear,
+    setValid: pricelistActions.medicalServicesSetValid,
+  },
+  [ITEMS_PRICELIST_TYPE]: {
+    check: pricelistActions.medicalItemsValidationCheck,
+    clear: pricelistActions.medicalItemsValidationClear,
+    setValid: pricelistActions.medicalItemsSetValid,
+  },
+};
 
 const StyledPricelistGeneralPanel = styled("div")(({ theme }) => ({
   "& .item": theme.paper?.item ?? {},
@@ -45,9 +51,18 @@ class PricelistGeneralPanel extends FormPanel {
   };
 
   shouldValidate = (inputValue) => {
-    const { savedServiceName, savedItemName } = this.props;
-    const shouldValidate = inputValue !== (savedServiceName || savedItemName);
-    return shouldValidate;
+    const { originalName, savedServiceName, savedItemName, edited } = this.props;
+    const baselineName = originalName || savedServiceName || savedItemName;
+
+    if (!edited?.uuid) {
+      return true;
+    }
+
+    if (!baselineName) {
+      return false;
+    }
+
+    return inputValue !== baselineName;
   };
   onCodeChange = (value) => {
     let filters = [`code_Icontains: "${value}"`, `first: 20`];
@@ -69,22 +84,29 @@ class PricelistGeneralPanel extends FormPanel {
       isMedicalItemValidating,
       medicalItemValidationError,
       activeType,
+      pricelistType,
+      originalName,
     } = this.props;
     const region = edited.location?.parent ?? edited.location;
     const district = edited.location?.parent ? edited.location : null;
-    const servicesOrItems = activeType === SERVICES_PRICELIST_TYPE;
+    const resolvedType = pricelistType || activeType;
+    const validationActions =
+      PRICELIST_VALIDATION_ACTIONS[resolvedType] ?? PRICELIST_VALIDATION_ACTIONS[SERVICES_PRICELIST_TYPE];
+    const isServicesPricelist = resolvedType === SERVICES_PRICELIST_TYPE;
+    const validationKey = `${edited?.uuid || "new"}-${originalName || "pending"}-${resolvedType || "unknown"}`;
     return (
       <StyledPricelistGeneralPanel>
         <Grid container>
           <Grid size={GRID_RESPONSIVE_STANDARD} className="item">
             <ValidatedTextInput
-              action={servicesOrItems ? medicalServicesValidationCheck : medicalItemsValidationCheck}
-              clearAction={servicesOrItems ? medicalServicesValidationClear : medicalItemsValidationClear}
-              setValidAction={servicesOrItems ? medicalServicesSetValid : medicalItemsSetValid}
-              itemQueryIdentifier={servicesOrItems ? "servicesPricelistName" : "itemsPricelistName"}
-              isValid={servicesOrItems ? isMedicalServiceValid : isMedicalItemValid}
-              isValidating={servicesOrItems ? isMedicalServiceValidating : isMedicalItemValidating}
-              validationError={servicesOrItems ? medicalServiceValidationError : medicalItemValidationError}
+              key={validationKey}
+              action={validationActions.check}
+              clearAction={validationActions.clear}
+              setValidAction={validationActions.setValid}
+              itemQueryIdentifier={isServicesPricelist ? "servicesPricelistName" : "itemsPricelistName"}
+              isValid={isServicesPricelist ? isMedicalServiceValid : isMedicalItemValid}
+              isValidating={isServicesPricelist ? isMedicalServiceValidating : isMedicalItemValidating}
+              validationError={isServicesPricelist ? medicalServiceValidationError : medicalItemValidationError}
               shouldValidate={this.shouldValidate}
               module="medical_pricelist"
               label="medical_pricelist.name"
@@ -116,7 +138,7 @@ class PricelistGeneralPanel extends FormPanel {
             <TextInput
               module="medical_pricelist"
               label={
-                !!this.props.activeType && this.props.activeType === "items"
+                resolvedType === ITEMS_PRICELIST_TYPE
                   ? `medical_pricelist.table.medicalItemName`
                   : `medical_pricelist.table.medicalServiceName`
               }
@@ -152,17 +174,35 @@ class PricelistGeneralPanel extends FormPanel {
   }
 }
 
-const mapStateToProps = (state) => ({
-  isMedicalServiceValid: state.medical_pricelist.validationFields?.medicalServices?.isValid,
-  isMedicalServiceValidating: state.medical_pricelist.validationFields?.medicalServices?.isValidating,
-  medicalServiceValidationError: state.medical_pricelist.validationFields?.medicalServices?.validationError,
-  savedServiceName: state.medical_pricelist?.pricelists?.services.item?.name,
-  isMedicalItemValid: state.medical_pricelist.validationFields?.medicalItems?.isValid,
-  isMedicalItemValidating: state.medical_pricelist.validationFields?.medicalItems?.isValidating,
-  medicalItemValidationError: state.medical_pricelist.validationFields?.medicalItems?.validationError,
-  savedItemName: state.medical_pricelist?.pricelists?.items.item?.name,
-  activeType: state.medical_pricelist?.services?.type || state.medical_pricelist?.items?.type,
-});
+const mapStateToProps = (state, props) => {
+  const editedUuid = props?.edited?.uuid;
+  const servicesState = state.medical_pricelist?.pricelists?.services;
+  const itemsState = state.medical_pricelist?.pricelists?.items;
+
+  return {
+    isMedicalServiceValid: state.medical_pricelist.validationFields?.medicalServices?.isValid,
+    isMedicalServiceValidating: state.medical_pricelist.validationFields?.medicalServices?.isValidating,
+    medicalServiceValidationError: state.medical_pricelist.validationFields?.medicalServices?.validationError,
+    savedServiceName:
+      servicesState?.item?.uuid === editedUuid
+        ? servicesState.item.name
+        : editedUuid
+          ? servicesState?.items?.[editedUuid]?.name
+          : undefined,
+    isMedicalItemValid: state.medical_pricelist.validationFields?.medicalItems?.isValid,
+    isMedicalItemValidating: state.medical_pricelist.validationFields?.medicalItems?.isValidating,
+    medicalItemValidationError: state.medical_pricelist.validationFields?.medicalItems?.validationError,
+    savedItemName:
+      itemsState?.item?.uuid === editedUuid
+        ? itemsState.item.name
+        : editedUuid
+          ? itemsState?.items?.[editedUuid]?.name
+          : undefined,
+    activeType: state.medical_pricelist?.services?.type || state.medical_pricelist?.items?.type,
+    pricelistType: props?.pricelistType,
+    originalName: props?.originalName,
+  };
+};
 
 export { StyledPricelistGeneralPanel };
 export default withHistory(withModulesManager(connect(mapStateToProps)(PricelistGeneralPanel)));

--- a/src/components/PricelistSelectAllButton.jsx
+++ b/src/components/PricelistSelectAllButton.jsx
@@ -1,51 +1,58 @@
 import React from "react";
 import { useTranslations } from "@openimis/fe-core";
-import { Button, Box } from "@mui/material";
+import { Button } from "@mui/material";
+import { isItemActive } from "../helpers/selection";
 
-export function SelectAllButton (details, props, edited, onEditedChanged) {
-    const {
-      modulesManager,
-    } = props;
-    const { formatMessage } = useTranslations("medical_pricelist", modulesManager);
+const PricelistSelectAllButton = ({ details, readOnly, edited, onEditedChanged, modulesManager }) => {
+  const { formatMessage } = useTranslations("medical_pricelist", modulesManager);
 
-    const page_details_uuids = details.items ? details.items.map(d => d.uuid) : []
-    const current_added_details = edited.addedDetails? edited.addedDetails : []
-    const areNotAllSelected = !current_added_details.includes(...page_details_uuids)
-    const current_removed_details = edited.removedDetails? edited.removedDetails : []
+  const pageItems = details?.items ?? [];
+  const pageUuids = pageItems.map((item) => item.uuid);
 
+  const allSelected = pageItems.length > 0 && pageItems.every((item) => isItemActive(edited, item));
 
-    if (areNotAllSelected) {
-        page_details_uuids.push(...current_removed_details)    
+  const handleTogglePage = () => {
+    const added = edited?.addedDetails ?? [];
+    const removed = edited?.removedDetails ?? [];
+
+    if (allSelected) {
+      // Unselect all items on this page
+      const newAdded = added.filter((uuid) => !pageUuids.includes(uuid));
+      const toRemove = pageItems.filter((item) => item.isActive).map((item) => item.uuid);
+      const newRemoved = [...new Set([...removed, ...toRemove])];
+
+      onEditedChanged({
+        ...edited,
+        addedDetails: newAdded,
+        removedDetails: newRemoved,
+      });
     } else {
-        page_details_uuids.push(...current_added_details)    
-    }
+      // Select all items on this page
+      const toAdd = pageItems.filter((item) => !item.isActive).map((item) => item.uuid);
+      const newAdded = [...new Set([...added, ...toAdd])];
+      const newRemoved = removed.filter((uuid) => !pageUuids.includes(uuid));
 
-    const new_details_uuids = [...new Set(page_details_uuids)]
-    //details.items.length > (!!edited.addedDetails? edited.addedDetails.length : 0)
-  
-    const selectAllEdited = () => {
-      try {
-        const addedDetails = areNotAllSelected ? new_details_uuids : current_removed_details;
-        const removedDetails = areNotAllSelected ? current_removed_details : new_details_uuids;
-        onEditedChanged({
-          ...edited,
-          addedDetails,
-          removedDetails
-        })
-      } catch (error) {
-        console.error(error);
-      }
+      onEditedChanged({
+        ...edited,
+        addedDetails: newAdded,
+        removedDetails: newRemoved,
+      });
     }
-    
-    return (
-          <Box flexGrow={1}>
-          <Box display="flex" justifyContent="flex-end">
-          <Button onClick={() => selectAllEdited()} color="primary" disabled={props.readOnly} fullWidth>
-        {areNotAllSelected ? formatMessage("medical_pricelist.table.selectAll") : formatMessage("medical_pricelist.table.unselectAll")}
-      </Button>
-          </Box>
-        </Box>
-    );
-  }
+  };
 
-export default SelectAllButton;
+  return (
+    <Button
+      onClick={handleTogglePage}
+      color="primary"
+      disabled={readOnly || pageItems.length === 0}
+      size="small"
+      className="selectAllBtn"
+    >
+      {allSelected
+        ? formatMessage("medical_pricelist.table.unselectAll")
+        : formatMessage("medical_pricelist.table.selectAll")}
+    </Button>
+  );
+};
+
+export default PricelistSelectAllButton;

--- a/src/components/PricelistsFilters.jsx
+++ b/src/components/PricelistsFilters.jsx
@@ -13,10 +13,10 @@ import {
 import { FormControlLabel, Grid, Checkbox } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-const StyledPricelistsFilter = styled('section')(({ theme }) => ({
+const StyledPricelistsFilter = styled("section")(({ theme }) => ({
   padding: "0 0 10px 0",
   width: "100%",
-  '& .item': {
+  "& .item": {
     padding: theme.spacing(1),
   },
 }));

--- a/src/components/PricelistsSearcher.jsx
+++ b/src/components/PricelistsSearcher.jsx
@@ -3,9 +3,8 @@ import React, { useCallback, useState } from "react";
 import { Tooltip, Button } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { GetIconComponent } from "@openimis/fe-core";
-const TabIcon = GetIconComponent("Tab")
-const DeleteIcon = GetIconComponent("Delete")
-
+const TabIcon = GetIconComponent("Tab");
+const DeleteIcon = GetIconComponent("Delete");
 
 import { combine, useTranslations, ConfirmDialog, Searcher, withModulesManager } from "@openimis/fe-core";
 import PricelistsFilters from "./PricelistsFilters";
@@ -17,8 +16,8 @@ const formatLocation = (location) => {
   return location ? `${location.code} - ${location.name}` : "";
 };
 
-const StyledPricelistsSearcher = styled('div')(({ theme }) => ({
-  '& .horizontalButtonContainer': theme.buttonContainer?.horizontal ?? {},
+const StyledPricelistsSearcher = styled("div")(({ theme }) => ({
+  "& .horizontalButtonContainer": theme.buttonContainer?.horizontal ?? {},
 }));
 
 const PricelistsSearcher = (props) => {
@@ -87,7 +86,7 @@ const PricelistsSearcher = (props) => {
       ),
     ];
   }, []);
-  
+
   const filtersToQueryParams = useCallback((state) => {
     const params = Object.keys(state.filters)
       .filter((contrib) => !!state.filters[contrib].filter)

--- a/src/helpers/pricelist.js
+++ b/src/helpers/pricelist.js
@@ -1,0 +1,15 @@
+export const normalizePrice = (price) => {
+  if (price == null || price === "") return null;
+  const num = Number(price);
+  return Number.isNaN(num) ? null : num;
+};
+
+export function getInitialOriginalName(pricelistUuid, locationState, storedPricelist) {
+  if (locationState?.pricelist?.uuid === pricelistUuid) {
+    return locationState.pricelist.name ?? null;
+  }
+  if (storedPricelist?.uuid === pricelistUuid) {
+    return storedPricelist.name ?? null;
+  }
+  return null;
+}

--- a/src/helpers/routing.js
+++ b/src/helpers/routing.js
@@ -1,0 +1,12 @@
+const PRICELIST_UUID_PATH = /\/medical\/pricelists\/(?:services|items)\/([^/]+)/;
+
+export function getPricelistUuid(params = {}, pathname = "") {
+  const routeUuid = params.price_list_uuid ?? params.price_list_id;
+  if (routeUuid && routeUuid !== "new") {
+    return routeUuid;
+  }
+
+  const match = pathname.match(PRICELIST_UUID_PATH);
+  const pathUuid = match?.[1];
+  return pathUuid && pathUuid !== "new" ? pathUuid : null;
+}

--- a/src/helpers/selection.js
+++ b/src/helpers/selection.js
@@ -1,0 +1,3 @@
+export const isItemActive = (edited, item) => {
+  return edited.addedDetails?.includes(item.uuid) || (item.isActive && !edited.removedDetails?.includes(item.uuid));
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,9 +8,11 @@ import ServicesPricelistsPage from "./pages/ServicesPricelistsPage";
 import ItemsPricelistsPage from "./pages/ItemsPricelistsPage";
 import ServicesPricelistDetailsPage from "./pages/ServicesPricelistDetailsPage";
 import ItemsPricelistDetailsPage from "./pages/ItemsPricelistDetailsPage";
-import { RIGHT_SERVICES_PRICELISTS, RIGHT_ITEMS_PRICELISTS} from "./constants"
+import { RIGHT_SERVICES_PRICELISTS, RIGHT_ITEMS_PRICELISTS } from "./constants";
 const DEFAULT_CONFIG = {
-  "translations": [{ key: "en", messages: messages_en }, { key: "fr", messages: messages_fr }],
+  "translations": [
+    { key: "en", messages: messages_en },
+  ],
   "reducers": [{ key: "medical_pricelist", reducer }],
   "refs": [
     { key: "medical_pricelist.ServicesPriceListPicker", ref: ServicesPricelistPicker },
@@ -30,34 +32,34 @@ const DEFAULT_CONFIG = {
   ],
   "core.Boot": [PriceListLoader],
   "core.Router": [
-    { 
+    {
       id: "medical_pricelist.servicesPricelist",
       text: "medical_pricelist.servicesPricelist",
       icon: "MedicalServices",
       path: "medical/pricelists/services",
       component: ServicesPricelistsPage,
-      rights: [RIGHT_SERVICES_PRICELISTS]
+      rights: [RIGHT_SERVICES_PRICELISTS],
     },
     { path: "medical/pricelists/services/new", component: ServicesPricelistDetailsPage },
-    { path: "medical/pricelists/services/:price_list_id", component: ServicesPricelistDetailsPage },
-    { 
+    { path: "medical/pricelists/services/:price_list_uuid", component: ServicesPricelistDetailsPage },
+    {
       id: "medical_pricelist.itemsPricelist",
       text: "medical_pricelist.itemsPricelist",
       icon: "Vaccines",
       path: "medical/pricelists/items",
       component: ItemsPricelistsPage,
-      rights: [RIGHT_ITEMS_PRICELISTS]
+      rights: [RIGHT_ITEMS_PRICELISTS],
     },
     { path: "medical/pricelists/items/new", component: ItemsPricelistDetailsPage },
-    { path: "medical/pricelists/items/:price_list_id", component: ItemsPricelistDetailsPage },
+    { path: "medical/pricelists/items/:price_list_uuid", component: ItemsPricelistDetailsPage },
   ],
   "admin.MainMenu": [
     {
-      route:  "medical/pricelists/services",
+      route: "medical/pricelists/services",
     },
     {
-      route:  "medical/pricelists/items",
-      withDivider: true
+      route: "medical/pricelists/items",
+      withDivider: true,
     },
   ],
 };

--- a/src/pages/ItemsPricelistDetailsPage.jsx
+++ b/src/pages/ItemsPricelistDetailsPage.jsx
@@ -1,70 +1,117 @@
-import React, { useState, useEffect } from "react";
-import { connect } from "react-redux";
+import React, { useState, useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import clsx from "clsx";
-import { bindActionCreators } from "redux";
-import { combine, withHistory, withModulesManager, historyPush, ProgressOrError } from "@openimis/fe-core";
 import { styled } from "@mui/material/styles";
-import { ErrorBoundary, useTranslations } from "@openimis/fe-core";
+import {
+  combine,
+  withHistory,
+  withModulesManager,
+  historyPush,
+  ProgressOrError,
+  useParams,
+  useLocation,
+  ErrorBoundary,
+  useTranslations,
+} from "@openimis/fe-core";
 import PricelistForm from "../components/PricelistForm";
 import {
   createItemsPricelist,
   updateItemsPricelist,
-  fetchItemsPricelistById,
+  fetchItemsPricelistByUuid,
   fetchItemsPricelistDetails,
+  medicalItemsSetValid,
 } from "../actions";
-import { RIGHT_ITEMS_PRICELISTS_EDIT } from "../constants";
+import { RIGHT_ITEMS_PRICELISTS_EDIT, ITEMS_PRICELIST_TYPE } from "../constants";
+import { getInitialOriginalName } from "../helpers/pricelist";
+import { getPricelistUuid } from "../helpers/routing";
 
-const StyledItemsPriceListDetailsPage = styled('div')(({ theme }) => ({
+const StyledItemsPriceListDetailsPage = styled("div")(({ theme }) => ({
   ...theme.page ?? {},
-  '&.locked': theme.page?.locked ?? {},
+  "&.locked": theme.page?.locked ?? {},
 }));
 
 const ItemsPriceListDetailsPage = (props) => {
-  const {
-    isFetching,
-    error,
-    match,
-    history,
-    modulesManager,
-    rights,
-    updateItemsPricelist,
-    fetchItemsPricelistById,
-    fetchItemsPricelistDetails,
-    createItemsPricelist,
-    details,
-  } = props;
+  const { history, modulesManager } = props;
+  const params = useParams();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const pricelistUuid = getPricelistUuid(params, location.pathname);
   const { formatMessageWithValues } = useTranslations("medical_pricelist", modulesManager);
+  const rights = useSelector((state) => state.core?.user?.i_user?.rights ?? []);
+  const pricelistState = useSelector((state) => state.medical_pricelist.pricelists.items);
+  const details = useSelector((state) => state.medical_pricelist.items);
+  const storedPricelist = useMemo(() => {
+    if (!pricelistUuid) {
+      return null;
+    }
+    if (pricelistState.item?.uuid === pricelistUuid) {
+      return pricelistState.item;
+    }
+    return pricelistState.items[pricelistUuid] ?? null;
+  }, [pricelistUuid, pricelistState.item, pricelistState.items]);
   const [isLocked, setLocked] = useState(false);
   const [resetKey, setResetKey] = useState(null);
-  const [pricelist, setPricelist] = useState({});
+  const [originalName, setOriginalName] = useState(() =>
+    getInitialOriginalName(pricelistUuid, location.state, null)
+  );
+  const [pricelist, setPricelist] = useState(() =>
+    location.state?.pricelist?.uuid === pricelistUuid ? location.state.pricelist : {}
+  );
 
   useEffect(() => {
-    if (match.params.price_list_id) {
-      fetchItemsPricelistById(modulesManager, match.params.price_list_id);
-    } else {
+    if (!pricelistUuid) {
       setPricelist({});
+      return;
     }
-  }, [match.params.price_list_id, resetKey]);
+    dispatch(fetchItemsPricelistByUuid(modulesManager, pricelistUuid));
+  }, [dispatch, modulesManager, pricelistUuid, resetKey]);
 
   useEffect(() => {
-    if (props.pricelist) {
-      setPricelist(props.pricelist);
+    if (!pricelistUuid) {
+      setPricelist({});
+      return;
     }
-  }, [props.pricelist]);
+    if (location.state?.pricelist?.uuid === pricelistUuid) {
+      setPricelist(location.state.pricelist);
+    }
+    if (storedPricelist?.uuid === pricelistUuid) {
+      setPricelist(storedPricelist);
+    }
+  }, [pricelistUuid, location.state, storedPricelist]);
+
+  useEffect(() => {
+    if (originalName) {
+      return;
+    }
+    const resolvedOriginalName = getInitialOriginalName(pricelistUuid, location.state, storedPricelist);
+    if (resolvedOriginalName) {
+      setOriginalName(resolvedOriginalName);
+    }
+  }, [originalName, pricelistUuid, location.state, storedPricelist]);
+
+  useEffect(() => {
+    if (originalName && pricelist?.uuid) {
+      dispatch(medicalItemsSetValid());
+    }
+  }, [originalName, pricelist?.uuid, dispatch]);
 
   const onSave = (pricelist) => {
     setLocked(true);
     if (pricelist.uuid) {
-      updateItemsPricelist(
-        modulesManager,
-        pricelist,
-        formatMessageWithValues("updatePricelist.mutationLabel", { name: pricelist.name })
+      dispatch(
+        updateItemsPricelist(
+          modulesManager,
+          pricelist,
+          formatMessageWithValues("updatePricelist.mutationLabel", { name: pricelist.name })
+        )
       );
     } else {
-      createItemsPricelist(
-        modulesManager,
-        pricelist,
-        formatMessageWithValues("createPricelist.mutationLabel", { name: pricelist.name })
+      dispatch(
+        createItemsPricelist(
+          modulesManager,
+          pricelist,
+          formatMessageWithValues("createPricelist.mutationLabel", { name: pricelist.name })
+        )
       );
     }
   };
@@ -75,18 +122,23 @@ const ItemsPriceListDetailsPage = (props) => {
   };
 
   const fetchDetails = (filters) => {
-    fetchItemsPricelistDetails(modulesManager, filters, pricelist?.id);
+    dispatch(fetchItemsPricelistDetails(modulesManager, filters, pricelist?.id));
   };
+
+  const isNew = !pricelistUuid;
+  const isReady = isNew || pricelist?.uuid === pricelistUuid;
 
   return (
     <StyledItemsPriceListDetailsPage className={clsx(pricelist.validityTo && "locked")}>
       <ErrorBoundary>
-        <ProgressOrError progress={isFetching} error={error} />
-        {!isFetching && (
+        <ProgressOrError progress={pricelistState.isFetching && !isReady} error={pricelistState.error} />
+        {isReady && (
           <PricelistForm
-            key={resetKey}
+            key={`${resetKey ?? "new"}-${originalName ?? pricelistUuid ?? "pending"}`}
             readOnly={!rights.includes(RIGHT_ITEMS_PRICELISTS_EDIT) || isLocked}
             pricelist={pricelist}
+            pricelistType={ITEMS_PRICELIST_TYPE}
+            originalName={originalName}
             onChange={setPricelist}
             onBack={() => historyPush(modulesManager, history, "medical_pricelist.itemsPricelists")}
             onSave={rights.includes(RIGHT_ITEMS_PRICELISTS_EDIT) ? onSave : undefined}
@@ -100,31 +152,7 @@ const ItemsPriceListDetailsPage = (props) => {
   );
 };
 
-const mapStateToProps = (state, props) => ({
-  rights: state.core?.user?.i_user?.rights ?? [],
-  pricelist: props.match.params.price_list_id
-    ? state.medical_pricelist.pricelists.items.items[props.match.params.price_list_id]
-    : null,
-  isFetching: state.medical_pricelist.pricelists.items.isFetching,
-  error: state.medical_pricelist.pricelists.items.error,
-  details: state.medical_pricelist.items,
-});
+const enhance = combine(withHistory, withModulesManager);
 
-const mapDispatchToProps = (dispatch) =>
-  bindActionCreators(
-    {
-      createItemsPricelist,
-      updateItemsPricelist,
-      fetchItemsPricelistById,
-      fetchItemsPricelistDetails,
-    },
-    dispatch
-  );
-
-const enhance = combine(
-  withHistory,
-  withModulesManager,
-  connect(mapStateToProps, mapDispatchToProps)
-);
 export { StyledItemsPriceListDetailsPage };
 export default enhance(ItemsPriceListDetailsPage);

--- a/src/pages/ItemsPricelistsPage.jsx
+++ b/src/pages/ItemsPricelistsPage.jsx
@@ -31,7 +31,14 @@ const ItemsPricelistsPage = (props) => {
   const data = useSelector((state) => state.medical_pricelist.summaries.items);
   const dispatch = useDispatch();
   const onDoubleClick = (row, newTab = false) => {
-    historyPush(modulesManager, history, "medical_pricelist.itemsPricelists", [row.id], newTab);
+    const pathname = `/${modulesManager.getRef("medical_pricelist.itemsPricelistDetails")}/${row.uuid}`;
+    if (newTab) {
+      const link = history.createHref({ pathname, state: { pricelist: row } });
+      const hasDynLink = modulesManager.getConf("fe-core", "useDynPermalinks", false);
+      window.open(hasDynLink ? `/?dyn=${btoa(link)}` : link);
+      return;
+    }
+    history.push({ pathname, state: { pricelist: row } });
   };
 
   const onAdd = () => {

--- a/src/pages/ServicesPricelistDetailsPage.jsx
+++ b/src/pages/ServicesPricelistDetailsPage.jsx
@@ -1,70 +1,117 @@
-import React, { useState, useEffect } from "react";
-import { connect } from "react-redux";
+import React, { useState, useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import clsx from "clsx";
-import { bindActionCreators } from "redux";
-import { combine, withHistory, withModulesManager, historyPush, ProgressOrError } from "@openimis/fe-core";
 import { styled } from "@mui/material/styles";
-import { ErrorBoundary, useTranslations } from "@openimis/fe-core";
+import {
+  combine,
+  withHistory,
+  withModulesManager,
+  historyPush,
+  ProgressOrError,
+  useParams,
+  useLocation,
+  ErrorBoundary,
+  useTranslations,
+} from "@openimis/fe-core";
 import PricelistForm from "../components/PricelistForm";
 import {
   createServicesPricelist,
   updateServicesPricelist,
-  fetchServicesPricelistById,
+  fetchServicesPricelistByUuid,
   fetchServicesPricelistDetails,
+  medicalServicesSetValid,
 } from "../actions";
-import { RIGHT_SERVICES_PRICELISTS_EDIT } from "../constants";
+import { RIGHT_SERVICES_PRICELISTS_EDIT, SERVICES_PRICELIST_TYPE } from "../constants";
+import { getInitialOriginalName } from "../helpers/pricelist";
+import { getPricelistUuid } from "../helpers/routing";
 
-const StyledServicesPriceListDetailsPage = styled('div')(({ theme }) => ({
+const StyledServicesPriceListDetailsPage = styled("div")(({ theme }) => ({
   ...theme.page ?? {},
-  '&.locked': theme.page?.locked ?? {},
+  "&.locked": theme.page?.locked ?? {},
 }));
 
 const ServicesPriceListDetailsPage = (props) => {
-  const {
-    isFetching,
-    error,
-    match,
-    history,
-    modulesManager,
-    rights,
-    updateServicesPricelist,
-    fetchServicesPricelistDetails,
-    fetchServicesPricelistById,
-    createServicesPricelist,
-    details,
-  } = props;
+  const { history, modulesManager } = props;
+  const params = useParams();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const pricelistUuid = getPricelistUuid(params, location.pathname);
   const { formatMessageWithValues } = useTranslations("medical_pricelist", modulesManager);
+  const rights = useSelector((state) => state.core?.user?.i_user?.rights ?? []);
+  const pricelistState = useSelector((state) => state.medical_pricelist.pricelists.services);
+  const details = useSelector((state) => state.medical_pricelist.services);
+  const storedPricelist = useMemo(() => {
+    if (!pricelistUuid) {
+      return null;
+    }
+    if (pricelistState.item?.uuid === pricelistUuid) {
+      return pricelistState.item;
+    }
+    return pricelistState.items[pricelistUuid] ?? null;
+  }, [pricelistUuid, pricelistState.item, pricelistState.items]);
   const [isLocked, setLocked] = useState(false);
   const [resetKey, setResetKey] = useState(null);
-  const [pricelist, setPricelist] = useState({});
+  const [originalName, setOriginalName] = useState(() =>
+    getInitialOriginalName(pricelistUuid, location.state, null)
+  );
+  const [pricelist, setPricelist] = useState(() =>
+    location.state?.pricelist?.uuid === pricelistUuid ? location.state.pricelist : {}
+  );
 
   useEffect(() => {
-    if (match.params.price_list_id) {
-      fetchServicesPricelistById(modulesManager, match.params.price_list_id);
-    } else {
+    if (!pricelistUuid) {
       setPricelist({});
+      return;
     }
-  }, [match.params.price_list_id, resetKey]);
+    dispatch(fetchServicesPricelistByUuid(modulesManager, pricelistUuid));
+  }, [dispatch, modulesManager, pricelistUuid, resetKey]);
 
   useEffect(() => {
-    if (props.pricelist) {
-      setPricelist(props.pricelist);
+    if (!pricelistUuid) {
+      setPricelist({});
+      return;
     }
-  }, [props.pricelist]);
+    if (location.state?.pricelist?.uuid === pricelistUuid) {
+      setPricelist(location.state.pricelist);
+    }
+    if (storedPricelist?.uuid === pricelistUuid) {
+      setPricelist(storedPricelist);
+    }
+  }, [pricelistUuid, location.state, storedPricelist]);
+
+  useEffect(() => {
+    if (originalName) {
+      return;
+    }
+    const resolvedOriginalName = getInitialOriginalName(pricelistUuid, location.state, storedPricelist);
+    if (resolvedOriginalName) {
+      setOriginalName(resolvedOriginalName);
+    }
+  }, [originalName, pricelistUuid, location.state, storedPricelist]);
+
+  useEffect(() => {
+    if (originalName && pricelist?.uuid) {
+      dispatch(medicalServicesSetValid());
+    }
+  }, [originalName, pricelist?.uuid, dispatch]);
 
   const onSave = (pricelist) => {
     setLocked(true);
     if (pricelist.uuid) {
-      updateServicesPricelist(
-        modulesManager,
-        pricelist,
-        formatMessageWithValues("updatePricelist.mutationLabel", { name: pricelist.name })
+      dispatch(
+        updateServicesPricelist(
+          modulesManager,
+          pricelist,
+          formatMessageWithValues("updatePricelist.mutationLabel", { name: pricelist.name })
+        )
       );
     } else {
-      createServicesPricelist(
-        modulesManager,
-        pricelist,
-        formatMessageWithValues("createPricelist.mutationLabel", { name: pricelist.name })
+      dispatch(
+        createServicesPricelist(
+          modulesManager,
+          pricelist,
+          formatMessageWithValues("createPricelist.mutationLabel", { name: pricelist.name })
+        )
       );
     }
   };
@@ -75,18 +122,23 @@ const ServicesPriceListDetailsPage = (props) => {
   };
 
   const fetchDetails = (filters) => {
-    fetchServicesPricelistDetails(modulesManager, filters, pricelist?.id);
+    dispatch(fetchServicesPricelistDetails(modulesManager, filters, pricelist?.id));
   };
+
+  const isNew = !pricelistUuid;
+  const isReady = isNew || pricelist?.uuid === pricelistUuid;
 
   return (
     <StyledServicesPriceListDetailsPage className={clsx(pricelist.validityTo && "locked")}>
       <ErrorBoundary>
-        <ProgressOrError progress={isFetching} error={error} />
-        {!isFetching && (
+        <ProgressOrError progress={pricelistState.isFetching && !isReady} error={pricelistState.error} />
+        {isReady && (
           <PricelistForm
-            key={resetKey}
+            key={`${resetKey ?? "new"}-${originalName ?? pricelistUuid ?? "pending"}`}
             readOnly={!rights.includes(RIGHT_SERVICES_PRICELISTS_EDIT) || isLocked}
             pricelist={pricelist}
+            pricelistType={SERVICES_PRICELIST_TYPE}
+            originalName={originalName}
             onChange={setPricelist}
             onBack={() => historyPush(modulesManager, history, "medical_pricelist.servicesPricelists")}
             onSave={rights.includes(RIGHT_SERVICES_PRICELISTS_EDIT) ? onSave : undefined}
@@ -100,31 +152,7 @@ const ServicesPriceListDetailsPage = (props) => {
   );
 };
 
-const mapStateToProps = (state, props) => ({
-  rights: state.core?.user?.i_user?.rights ?? [],
-  pricelist: props.match.params.price_list_id
-    ? state.medical_pricelist.pricelists.services.items[props.match.params.price_list_id]
-    : null,
-  isFetching: state.medical_pricelist.pricelists.services.isFetching,
-  error: state.medical_pricelist.pricelists.services.error,
-  details: state.medical_pricelist.services,
-});
+const enhance = combine(withHistory, withModulesManager);
 
-const mapDispatchToProps = (dispatch) =>
-  bindActionCreators(
-    {
-      createServicesPricelist,
-      updateServicesPricelist,
-      fetchServicesPricelistById,
-      fetchServicesPricelistDetails,
-    },
-    dispatch
-  );
-
-const enhance = combine(
-  withHistory,
-  withModulesManager,
-  connect(mapStateToProps, mapDispatchToProps)
-);
 export { StyledServicesPriceListDetailsPage };
 export default enhance(ServicesPriceListDetailsPage);

--- a/src/pages/ServicesPricelistsPage.jsx
+++ b/src/pages/ServicesPricelistsPage.jsx
@@ -31,7 +31,14 @@ const ServicesPricelistsPage = (props) => {
   const dispatch = useDispatch();
 
   const onDoubleClick = (row, newTab = false) => {
-    historyPush(modulesManager, history, "medical_pricelist.servicesPricelistDetails", [row.id], newTab);
+    const pathname = `/${modulesManager.getRef("medical_pricelist.servicesPricelistDetails")}/${row.uuid}`;
+    if (newTab) {
+      const link = history.createHref({ pathname, state: { pricelist: row } });
+      const hasDynLink = modulesManager.getConf("fe-core", "useDynPermalinks", false);
+      window.open(hasDynLink ? `/?dyn=${btoa(link)}` : link);
+      return;
+    }
+    history.push({ pathname, state: { pricelist: row } });
   };
 
   const onAdd = () => {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,6 @@
 import { formatServerError, formatGraphQLError, parseData, pageInfo } from "@openimis/fe-core";
 import { SERVICES_PRICELIST_TYPE, ITEMS_PRICELIST_TYPE } from "./constants";
+import { normalizePrice } from "./helpers/pricelist";
 
 function arrayToMap(arr) {
   return arr.reduce((map, a) => {
@@ -35,12 +36,14 @@ function reducer(
     pricelists: {
       services: {
         isFetching: false,
+        fetchedPricelist: false,
         items: {},
         item: {},
         error: null,
       },
       items: {
         isFetching: false,
+        fetchedPricelist: false,
         items: {},
         item: {},
         error: null,
@@ -77,11 +80,12 @@ function reducer(
       };
     case "MEDICAL_PRICELIST_SERVICES_RESP":
       const formatService = (service) => {
-        const isActive = service.pricelistDetails?.edges.length > 0 ?? false;
+        const isActive = !!service.pricelistDetails?.edges?.length;
         const d = {
           ...service,
           isActive,
-          priceOverrule: isActive ? service.pricelistDetails.edges[0].node.priceOverrule : undefined,
+          price: normalizePrice(service.price),
+          priceOverrule: isActive ? normalizePrice(service.pricelistDetails.edges[0].node.priceOverrule) : undefined,
         };
         delete d.pricelistDetails;
         return d;
@@ -121,11 +125,12 @@ function reducer(
       };
     case "MEDICAL_PRICELIST_ITEMS_RESP":
       const formatItem = (item) => {
-        const isActive = item.pricelistDetails?.edges.length > 0 ?? false;
+        const isActive = !!item.pricelistDetails?.edges?.length;
         const d = {
           ...item,
           isActive,
-          priceOverrule: isActive ? item.pricelistDetails.edges[0].node.priceOverrule : undefined,
+          price: normalizePrice(item.price),
+          priceOverrule: isActive ? normalizePrice(item.pricelistDetails.edges[0].node.priceOverrule) : undefined,
         };
         delete d.pricelistDetails;
         return d;
@@ -158,11 +163,16 @@ function reducer(
           [action.meta.pricelistType]: {
             ...state.pricelists[action.meta.pricelistType],
             isFetching: true,
+            fetchedPricelist: false,
             error: null,
           },
         },
       };
-    case "MEDICAL_PRICELIST_PRICELIST_RESP":
+    case "MEDICAL_PRICELIST_PRICELIST_RESP": {
+      const payloadField =
+        action.meta.pricelistType === SERVICES_PRICELIST_TYPE ? "servicesPricelists" : "itemsPricelists";
+      const pricelist = parseData(action.payload.data[payloadField])?.[0] ?? null;
+      const cacheKey = pricelist?.uuid ?? action.meta.pricelistUuid;
       return {
         ...state,
         pricelists: {
@@ -170,14 +180,18 @@ function reducer(
           [action.meta.pricelistType]: {
             ...state.pricelists[action.meta.pricelistType],
             isFetching: false,
-            items: {
-              ...state.pricelists[action.meta.pricelistType].items,
-              [action.payload.data.node.id]: action.payload.data.node,
-            },
-            item: action.payload.data.node,
+            fetchedPricelist: true,
+            items: pricelist && cacheKey
+              ? {
+                  ...state.pricelists[action.meta.pricelistType].items,
+                  [cacheKey]: pricelist,
+                }
+              : state.pricelists[action.meta.pricelistType].items,
+            item: pricelist ?? {},
           },
         },
       };
+    }
     case "MEDICAL_PRICELIST_PRICELIST_ERR":
       return {
         ...state,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -21,8 +21,8 @@
   "medical_pricelist.pricelistForm.table.title": "Details",
   "medical_pricelist.pricelistForm.emptyTitle": "New Pricelist",
   "medical_pricelist.table.code": "Code",
-  "medical_pricelist.table.overrule": "Price",
-  "medical_pricelist.table.price": "Price",
+  "medical_pricelist.table.overrule": "List Price",
+  "medical_pricelist.table.price": "Base Price",
   "medical_pricelist.table.name": "Name",
   "medical_pricelist.table.type": "Type",
   "medical_pricelist.table.type.c": "Curative",
@@ -51,7 +51,6 @@
   "medical_pricelist.gql_mutation_pricelists_medical_services_update_perms": "Medical Pricelist | Mutation Pricelists Medical Services Update",
   "medical_pricelist.gql_mutation_pricelists_medical_services_delete_perms": "Medical Pricelist | Mutation Pricelists Medical Services Delete",
   "medical_pricelist.gql_mutation_pricelists_medical_services_duplicate_perms": "Medical Pricelist | Mutation Pricelists Medical Services Duplicate",
-  "medical_pricelist.table.medicalItemName": "Product Name", 
-  "medical_pricelist.table.medicalServiceName": "Service Name"    
-
+  "medical_pricelist.table.medicalItemName": "Product Name",
+  "medical_pricelist.table.medicalServiceName": "Service Name"
 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,4 +1,6 @@
 {
-    "medical_pricelist.table.medicalItemName": "Nom du produit", 
-    "medical_pricelist.table.medicalServiceName": "Nom du service"    
+  "medical_pricelist.table.medicalItemName": "Nom du produit",
+  "medical_pricelist.table.medicalServiceName": "Nom du service",
+  "medical_pricelist.table.price": "Prix de base",
+  "medical_pricelist.table.overrule": "Prix sur la liste"
 }


### PR DESCRIPTION
…ching

Replace `formatNodeQuery` with `formatPageQuery` using UUID filters for fetching services and items pricelists. Update navigation in detail pages to use UUID-based routing instead of numeric IDs, passing pricelist data via history state to avoid redundant fetches. Add `normalizePrice` helper to sanitize price overrule values before mutation. Migrate components from class-based Redux (`connect`/`bindActionCreators`) to hooks (`useDispatch`/ `useSelector`) for consistency.

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
