### PR TITLE
feat(pricelist): add filter on name and code for items/services

### DIFF
--- a/src/components/PricelistDetailsPanel.jsx
+++ b/src/components/PricelistDetailsPanel.jsx
@@ -1,19 +1,35 @@
 import React, { useState, useEffect } from "react";
 import { styled } from "@mui/material/styles";
-import { Table, withModulesManager, combine, useTranslations, ErrorBoundary } from "@openimis/fe-core";
-import { Paper, Grid, Typography, Checkbox, Button} from "@mui/material";
+import {
+  Table,
+  withModulesManager,
+  combine,
+  useTranslations,
+  ErrorBoundary,
+  ControlledField,
+  TextInput,
+} from "@openimis/fe-core";
+import { Paper, Grid, Typography, Checkbox, Button } from "@mui/material";
 import PriceOverruleDialog from "./PriceOverruleDialog";
-import SelectAllButton from "./PricelistSelectAllButton" 
+import SelectAllButton from "./PricelistSelectAllButton";
 
-const StyledPricelistDetailsPanel = styled('div')(({ theme }) => ({
-  '& .paper': theme.paper?.paper ?? {},
-  '& .item': theme.paper?.item ?? {},
-  '& .tableTitle': theme.table?.title ?? {},
-  '& .checkbox': {
+const StyledPricelistDetailsPanel = styled("div")(({ theme }) => ({
+  "& .paper": theme.paper?.paper ?? {},
+  "& .item": theme.paper?.item ?? {},
+  "& .tableTitle": theme.table?.title ?? {},
+  "& .checkbox": {
     padding: theme.spacing(0),
   },
-  '& .editDetailBtn': {
+  "& .editDetailBtn": {
     padding: 0,
+  },
+  "& .filtersContainer": {
+    padding: theme.spacing(2),
+    paddingBottom: 0,
+    alignItems: "center",
+  },
+  "& .filterField": {
+    maxWidth: 400,
   },
 }));
 
@@ -32,38 +48,61 @@ const isItemActive = (edited, item) => {
 };
 
 const PricelistDetailsPanel = (props) => {
-  const {
-    modulesManager,
-    pageSize = 20,
-    edited,
-    edited_id,
-    readOnly,
-    details,
-    fetchDetails,
-    onEditedChanged,
-  } = props;
+  const { modulesManager, pageSize = 20, edited, edited_id, readOnly, details, fetchDetails, onEditedChanged } = props;
   const { formatMessage } = useTranslations("medical_pricelist", modulesManager);
   const [pagination, setPagination] = useState({ page: 0, afterCursor: null, beforeCursor: null });
   const [editedDetail, setEditedDetail] = useState(null);
-  
-  const ButtonHeader = (_) => {
-    return SelectAllButton(details, props, edited, onEditedChanged)
-  }
+  const [filters, setFilters] = useState({ code: "", name: "" });
+  // Debounced filter values
+  const [debouncedFilters, setDebouncedFilters] = useState({ code: "", name: "" });
 
-  HEADERS[0] = ButtonHeader
+  const ButtonHeader = (_) => {
+    return SelectAllButton(details, props, edited, onEditedChanged);
+  };
+
+  HEADERS[0] = ButtonHeader;
+
+  // Debounce logic
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedFilters({
+        code: filters.code.trim(),
+        name: filters.name.trim(),
+      });
+    }, modulesManager.getConf("fe-admin", "debounceTime", 500));
+
+    return () => clearTimeout(timer);
+  }, [filters.code, filters.name]);
+
+  // Reset pagination when filters change
+  useEffect(() => {
+    setPagination({ page: 0, afterCursor: null, beforeCursor: null });
+  }, [debouncedFilters]);
 
   useEffect(() => {
-    const filters = [];
+    const filterParams = [];
+
+    // Add pagination parameters
     if (pagination.afterCursor) {
-      filters.push(`first: ${pageSize}`, `after: "${pagination.afterCursor}"`);
+      filterParams.push(`first: ${pageSize}`, `after: "${pagination.afterCursor}"`);
     } else if (pagination.beforeCursor) {
-      filters.push(`last: ${pageSize}`, `before: "${pagination.beforeCursor}"`);
+      filterParams.push(`last: ${pageSize}`, `before: "${pagination.beforeCursor}"`);
     } else {
-      filters.push(`first: ${pageSize}`);
+      filterParams.push(`first: ${pageSize}`);
     }
 
-    fetchDetails(filters);
-  }, [pagination.page, edited_id]);
+    // Add code filter if present
+    if (debouncedFilters.code) {
+      filterParams.push(`code_Icontains: "${debouncedFilters.code}"`);
+    }
+
+    // Add name filter if present
+    if (debouncedFilters.name) {
+      filterParams.push(`name_Icontains: "${debouncedFilters.name}"`);
+    }
+
+    fetchDetails(filterParams);
+  }, [pagination.page, edited_id, debouncedFilters]);
 
   const onDetailChange = (event, item) => {
     if (event.target.checked) {
@@ -94,6 +133,13 @@ const PricelistDetailsPanel = (props) => {
     setEditedDetail(null);
   };
 
+  const handleFilterChange = (field) => (value) => {
+    setFilters((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
   return (
     <StyledPricelistDetailsPanel>
       {editedDetail && (
@@ -118,6 +164,43 @@ const PricelistDetailsPanel = (props) => {
             </Grid>
           </Grid>
           <Grid container>
+            {/* Filters - same line */}
+            <Grid size={12}>
+              <Grid container spacing={2} className="filtersContainer">
+                <Grid size={{ xs: 12, sm: 6, md: 4 }} className="filterField">
+                  <ControlledField
+                    module="medical_pricelist"
+                    id="medicalPricelistsFilter.details.code"
+                    field={
+                      <TextInput
+                        module="medical_pricelist"
+                        name="code"
+                        label={formatMessage("medical_pricelist.detailsFilter.code.label")}
+                        value={filters.code}
+                        onChange={handleFilterChange("code")}
+                        placeholder={formatMessage("medical_pricelist.detailsFilter.code.placeholder")}
+                      />
+                    }
+                  />
+                </Grid>
+                <Grid size={{ xs: 12, sm: 6, md: 4 }} className="filterField">
+                  <ControlledField
+                    module="medical_pricelist"
+                    id="medicalPricelistsFilter.details.name"
+                    field={
+                      <TextInput
+                        module="medical_pricelist"
+                        name="name"
+                        label={formatMessage("medical_pricelist.detailsFilter.name.label")}
+                        value={filters.name}
+                        onChange={handleFilterChange("name")}
+                        placeholder={formatMessage("medical_pricelist.detailsFilter.name.placeholder")}
+                      />
+                    }
+                  />
+                </Grid>
+              </Grid>
+            </Grid>
             <Grid size={12} className="item">
               <Table
                 error={details.error}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -29,6 +29,10 @@
   "medical_pricelist.table.type.p": "Preventative",
   "medical_pricelist.table.type.d": "Drug",
   "medical_pricelist.table.editOverruleButton": "Edit",
+  "medical_pricelist.detailsFilter.code.label": "Code",
+  "medical_pricelist.detailsFilter.code.placeholder": "Filter by code",
+  "medical_pricelist.detailsFilter.name.label": "Name",
+  "medical_pricelist.detailsFilter.name.placeholder": "Filter by name",
   "medical_pricelist.priceOverruleDialog.title": "Override Price",
   "medical_pricelist.priceOverruleDialog.message": "You can override the price of this element for this pricelist",
   "medical_pricelist.priceOverruleDialog.yes.button": "Save",
@@ -51,7 +55,6 @@
   "medical_pricelist.gql_mutation_pricelists_medical_services_update_perms": "Medical Pricelist | Mutation Pricelists Medical Services Update",
   "medical_pricelist.gql_mutation_pricelists_medical_services_delete_perms": "Medical Pricelist | Mutation Pricelists Medical Services Delete",
   "medical_pricelist.gql_mutation_pricelists_medical_services_duplicate_perms": "Medical Pricelist | Mutation Pricelists Medical Services Duplicate",
-  "medical_pricelist.table.medicalItemName": "Product Name", 
-  "medical_pricelist.table.medicalServiceName": "Service Name"    
-
+  "medical_pricelist.table.medicalItemName": "Product Name",
+  "medical_pricelist.table.medicalServiceName": "Service Name"
 }


### PR DESCRIPTION
## Description

  Adds debounced code/name filters to the items and services lists in the pricelist details panel. The user can now
  filter the table by item/service code or name directly from the details view, without leaving the page. Filter
  inputs are debounced (configurable via the module config) to avoid firing a request on every keystroke, and changing
  a filter resets the pagination so the result set always starts at page 1. Each input now has a proper label and
  placeholder, added to the translation file so the feature is fully translatable.

  Why is it needed? On large pricelists, finding a specific item or service by scrolling is impractical. This change
  provides a fast, server-side-filtered search (by code and/or name) right inside the details panel, which also keeps
  the UI consistent with the other list modules in the frontend packages.

  ## Type of Change

  - [x] Feature
  - [ ] Bug fix
  - [ ] Chore (Refactor, Docs, CI/CD)
  - [ ] Other, please specify

  ## Related Issue(s) / Task(s)

  - [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
  - [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
  - [x] External reference (e.g., Jira)

  ## Demo

  ## Checklist

  - [ ] Unit tests added/modified
  - [x] I18n / translation handled